### PR TITLE
Add scale / shift support to Matrix Convert<>

### DIFF
--- a/Emgu.CV/Matrix.cs
+++ b/Emgu.CV/Matrix.cs
@@ -299,6 +299,8 @@ namespace Emgu.CV
       /// Convert this matrix to different depth
       /// </summary>
       /// <typeparam name="TOtherDepth">The depth type to convert to</typeparam>
+      /// <param name="scale">the scaling factor to apply during conversion (defaults to 1.0 -- no scaling)</param>
+      /// <param name="shift">the shift factor to apply during conversion (defaults to 0.0 -- no shifting)</param>
       /// <returns>Matrix of different depth</returns>
       public Matrix<TOtherDepth> Convert<TOtherDepth>(double scale = 1.0, double shift = 0.0)  
          where TOtherDepth : new ()

--- a/Emgu.CV/Matrix.cs
+++ b/Emgu.CV/Matrix.cs
@@ -300,11 +300,11 @@ namespace Emgu.CV
       /// </summary>
       /// <typeparam name="TOtherDepth">The depth type to convert to</typeparam>
       /// <returns>Matrix of different depth</returns>
-      public Matrix<TOtherDepth> Convert<TOtherDepth>()  
+      public Matrix<TOtherDepth> Convert<TOtherDepth>(double scale = 1.0, double shift = 0.0)  
          where TOtherDepth : new ()
       {
          Matrix<TOtherDepth> res = new Matrix<TOtherDepth>(Rows, Cols, NumberOfChannels);
-         CvInvoke.cvConvertScale(Ptr, res.Ptr, 1.0, 0.0);
+         CvInvoke.cvConvertScale(Ptr, res.Ptr, scale, shift);
          return res;
       }
 


### PR DESCRIPTION
Often times, when converting pixel formats, we need to scale/shift the raw values (say, from going to an 8-bit grayscale image to a 16-bit grayscale image). This modification allows optionally scaling and shifting during the conversion. Since sensible default parameters (1.0 scaling, 0.0 shifting) are provided, this update won't break existing code.