### PR TITLE
Fix #41 - mask null reference

### DIFF
--- a/Emgu.CV.Cuda/Imgproc/CudaGoodFeaturesToTrackDetector.cs
+++ b/Emgu.CV.Cuda/Imgproc/CudaGoodFeaturesToTrackDetector.cs
@@ -33,7 +33,7 @@ namespace Emgu.CV.Cuda
       {
          using (InputArray iaImage = image.GetInputArray())
          using (OutputArray oaCorners = corners.GetOutputArray())
-         using (InputArray iaMask = (mask == null ? mask.GetInputArray() : InputArray.GetEmpty()))
+         using (InputArray iaMask = (mask != null ? mask.GetInputArray() : InputArray.GetEmpty()))
             CudaInvoke.cudaCornersDetectorDetect(_ptr, iaImage, oaCorners, iaMask, stream);
       }
 


### PR DESCRIPTION
Changed comparison mode to ```not equal``` to prevent acessing method of ```null``` element
Fixed issue [#41](https://github.com/emgucv/emgucv/issues/41)