### PR TITLE
Fixing the build of a few broken examples

### DIFF
--- a/Emgu.CV.Example/MotionDetection/Form1.cs
+++ b/Emgu.CV.Example/MotionDetection/Form1.cs
@@ -21,7 +21,7 @@ namespace MotionDetection
    {
       private VideoCapture _capture;
       private MotionHistory _motionHistory;
-      private BackgroundSubtractor _forgroundDetector;
+      private IBackgroundSubtractor _forgroundDetector;
 
       public Form1()
       {

--- a/Emgu.CV.Example/VideoSurveilance/VideoSurveilance.cs
+++ b/Emgu.CV.Example/VideoSurveilance/VideoSurveilance.cs
@@ -23,7 +23,7 @@ namespace VideoSurveilance
       
       private static VideoCapture _cameraCapture;
       
-      private static BackgroundSubtractor _fgDetector;
+      private static IBackgroundSubtractor _fgDetector;
       private static Emgu.CV.Cvb.CvBlobDetector _blobDetector;
       private static Emgu.CV.Cvb.CvTracks _tracker;
 


### PR DESCRIPTION
Apparently a class named BackgroundSubtractor no longer exists in the project. I replaced it with the new interface, IBackgroundSubtractor