### PR TITLE
Improve library loading

### DIFF
--- a/Emgu.Util/Toolbox.cs
+++ b/Emgu.Util/Toolbox.cs
@@ -528,7 +528,7 @@ namespace Emgu.Util
                 //const int loadLibrarySearchApplicationDir = 0x00000200;
                 //const int loadLibrarySearchUserDirs = 0x00000400;
                 int dwFlags = loadLibrarySearchDefaultDirs;
-                if (System.IO.Path.IsPathFullyQualified(dllname))
+                if (dllname.Length >= 2 && (dllname[1] == ':' || (dllname[0] == '\\' && dllname[1] == '\\')))
                     dwFlags |= loadLibrarySearchDllLoadDir; 
                 IntPtr handler = LoadLibraryEx(dllname, IntPtr.Zero, dwFlags);
                 if (handler == IntPtr.Zero)

--- a/Emgu.Util/Toolbox.cs
+++ b/Emgu.Util/Toolbox.cs
@@ -527,7 +527,12 @@ namespace Emgu.Util
                 const int loadLibrarySearchDefaultDirs = 0x00001000;
                 //const int loadLibrarySearchApplicationDir = 0x00000200;
                 //const int loadLibrarySearchUserDirs = 0x00000400;
-                IntPtr handler = LoadLibraryEx(dllname, IntPtr.Zero, loadLibrarySearchDllLoadDir | loadLibrarySearchDefaultDirs);
+                int dwFlags = loadLibrarySearchDefaultDirs;
+                if (System.IO.Path.IsPathFullyQualified(dllname))
+                    dwFlags |= loadLibrarySearchDllLoadDir; 
+                IntPtr handler = LoadLibraryEx(dllname, IntPtr.Zero, dwFlags);
+                if (handler == IntPtr.Zero)
+                    handler = LoadLibraryEx(dllname, IntPtr.Zero, 0);
                 //IntPtr handler = LoadLibraryEx(dllname, IntPtr.Zero, loadLibrarySearchUserDirs);
                 if (handler == IntPtr.Zero)
                 {


### PR DESCRIPTION
Hello,

first of all, great work! However, I think I found a small bug and also would like to suggest an improvement. In my setup, I only use 64-bit builds and copied the unmanaged 64-bit DLLs into a directory that I have added to my Path environement variable such that I can share the DLLs and do not need to copy them in each program directory. This saves a significant amount of hard disc space. Here, I first get the following error reported from EmguCV:

> LoadLibraryEx cvextern.dll failed with error code 87: The parameter is incorrect.
> Failed to load cvextern.dll using default path
> !!! Failed to load cvextern.dll.`

Interestingly, the whole application runs fine without any problems. Still, CvInvoke.Init() returns false because the static constructor did not initialize the libraries. Here, I would like to suggest two improvements. At first, if the file to load in Toolbox.LoadLibrary() does not contain a fully qualified path, the flag loadLibrarySearchDllLoadDir (0x00000100) is incorrect. I think that's why LoadLibraryEx() complains about an incorrect parameter. This flag only has an effect if the DLL is loaded from a full path such that this path is also used to resolve dependencies. Even though the DLLs path could also be used to resolve the dependencies in any case, for some reason the function is not implemented this way. Thus, I would like to suggest to set the hwFlags accordingly.

The next improvement directly refers to loading the unmanaged DLLs from the Path environment variable. The currently implemented logic would not load the libraries here, still the application will do so anyway. Presumably during the first call to an imported function from cvextern.dll. This improvement will result in a correct initialization in CvInvoke's static constructor such that CvInvoke.Init() will return true as well.

Would appreciate if you accept my PR.