### PR TITLE
Update Image.cs

### DIFF
--- a/Emgu.CV/Core/Image.cs
+++ b/Emgu.CV/Core/Image.cs
@@ -44,6 +44,27 @@ namespace Emgu.CV
         protected Image()
         {
         }
+            
+        /// <summary>
+        /// Create an Image from an existing one and move its data to the new one
+        /// </summary>
+        /// <param name="img">the existing source image whose data is moved to the new image</param>
+        protected Image(Image<TColor, TDepth> img)
+        {
+            if (img != null)
+            {
+                _ptr = img._ptr;
+                _dataHandle = img._dataHandle;
+                _imageDataReleaseMode = img._imageDataReleaseMode;
+                _array = img._array;
+
+                img._ptr = IntPtr.Zero;
+                img._dataHandle = new GCHandle();
+                img._imageDataReleaseMode = ImageDataReleaseMode.ReleaseHeaderOnly;
+                img._array = null;
+                img.Dispose();
+            }
+        }            
 
         /// <summary>
         /// Create image from the specific multi-dimensional data, where the 1st dimension is # of rows (height), the 2nd dimension is # cols (width) and the 3rd dimension is the channel


### PR DESCRIPTION
We would like to suggest an additional constructor for the Image class to improve its usability in inheritance chains.
Deriving a child class from Image is possible, however all inherited functions that return Image instances return base class object (Image instances) only.
For example, DerivedImage.Clone() will return only an Image, but not a DerivedImage, and the temporary Image instance has to be converted into a DerivedImage.
This requires an explicit instantiation of DerivedImage.
Currently, the latter cannot be performed without copying the data from the temporary source image (i.e. the return value of the inherited member function like Clone()) into the new one.
Here, the additional protected Image constructor allows to move the data from the temporary source image into the newly created one.
Alternatively, this functionality could also be implemented in method that swaps the member variables between two Image instances, but it requires access to private data members as welll such that it also requires an extension of your sources.
Therefore, we found this modification to be the best suited one for this functionality and would appreciate if you accept our proposed modifications.
Thanks in advance!