### PR TITLE
Fix documentation strings for Inter enum values

### DIFF
--- a/Emgu.CV/PInvoke/CvEnum/Inter.cs
+++ b/Emgu.CV/PInvoke/CvEnum/Inter.cs
@@ -20,11 +20,11 @@ namespace Emgu.CV.CvEnum
         /// </summary>
         Linear = 1,
         /// <summary>
-        /// Resampling using pixel area relation. It is the preferred method for image decimation that gives moire-free results. In case of zooming it is similar to CV_INTER_NN method
+        /// Bicubic interpolation
         /// </summary>
         Cubic = 2,
         /// <summary>
-        /// Bicubic interpolation
+        /// Resampling using pixel area relation. It is the preferred method for image decimation that gives moire-free results. In case of zooming it is similar to CV_INTER_NN method
         /// </summary>
         Area = 3,
         /// <summary>


### PR DESCRIPTION
The docstrings for Cubic and Area Inter values were mistakenly swapped. See the OpenCV documentation here: https://docs.opencv.org/4.5.2/da/d54/group__imgproc__transform.html#ga5bb5a1fea74ea38e1a5445ca803ff121