### PR TITLE
Call LoadPackagedLibrary() from Windows 8 onwards

### DIFF
--- a/Emgu.Util/Toolbox.cs
+++ b/Emgu.Util/Toolbox.cs
@@ -563,7 +563,8 @@ namespace Emgu.Util
                 handler = LoadLibraryExWindows(dllname, 0);
             }
 
-            if (handler == IntPtr.Zero)
+            // LoadPackagedLibrary() is supported from Windows 8 (6.2) onwards
+            if (handler == IntPtr.Zero && Environment.OSVersion.Version >= new Version(6, 2))
             {
                 //Also try loadPackagedLibrary
                 IntPtr packagedLibraryHandler = LoadPackagedLibrary(dllname, 0);


### PR DESCRIPTION
The LoadPackagedLibrary() function was introduced in Windows 8 (Version 6.2).
The function is only called if any previews calls of LoadLibraryEx() fails. This can particullarly be the case for lean distributions of EmguCV.
To assure backward compatibility with Windows 7 (Version 6.1) the function must not be called for OS versions less than 6.2.

Issue: #702 