### PR TITLE
Make Zlib util methods public

### DIFF
--- a/Emgu.CV/Util/CvInvokeUtil.cs
+++ b/Emgu.CV/Util/CvInvokeUtil.cs
@@ -2,10 +2,7 @@
 //  Copyright (C) 2004-2022 by EMGU Corporation. All rights reserved.       
 //----------------------------------------------------------------------------
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
-using Emgu.Util;
 using System.Drawing;
 
 namespace Emgu.CV
@@ -42,12 +39,12 @@ namespace Emgu.CV
         internal static extern void tbbTaskSchedulerRelease(ref IntPtr scheduler);
 
         [DllImport(CvInvoke.ExternLibrary, CallingConvention = CvInvoke.CvCallingConvention)]
-        internal static extern int zlib_compress_bound(int length);
+        public static extern int zlib_compress_bound(int length);
 
         [DllImport(CvInvoke.ExternLibrary, CallingConvention = CvInvoke.CvCallingConvention)]
-        internal static extern void zlib_compress2(IntPtr dataCompressed, ref int sizeDataCompressed, IntPtr dataOriginal, int sizeDataOriginal, int compressionLevel);
+        public static extern void zlib_compress2(IntPtr dataCompressed, ref int sizeDataCompressed, IntPtr dataOriginal, int sizeDataOriginal, int compressionLevel);
 
         [DllImport(CvInvoke.ExternLibrary, CallingConvention = CvInvoke.CvCallingConvention)]
-        internal static extern void zlib_uncompress(IntPtr dataUncompressed, ref int sizeDataUncompressed, IntPtr compressedData, int sizeDataCompressed);
+        public static extern void zlib_uncompress(IntPtr dataUncompressed, ref int sizeDataUncompressed, IntPtr compressedData, int sizeDataCompressed);
     }
 }

--- a/Emgu.CV/Util/ZlibCompression.cs
+++ b/Emgu.CV/Util/ZlibCompression.cs
@@ -3,8 +3,6 @@
 //----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Runtime.InteropServices;
 
 namespace Emgu.CV.Util
@@ -12,7 +10,7 @@ namespace Emgu.CV.Util
     /// <summary>
     /// Use zlib included in OpenCV to perform in-memory binary compression and decompression
     /// </summary>
-    internal static class ZlibCompression
+    public static class ZlibCompression
     {
         /// <summary>
         /// Compress the data using the specific compression level


### PR DESCRIPTION
Request from https://github.com/emgucv/emgucv/discussions/751

Such methods can be useful, including to me.
For example, it can provide a fast way to compress and decompress a Mat to use a high count of Mat on the stack.
CvInvoke methods are also very important to be public, since we can compress a Mat directly without get a copy of bytes using the data `IntPrt` 