### PR TITLE
Maui: fix ambiguous TextAlignment reference breaking the Android build

### DIFF
--- a/Emgu.CV.Runtime/Maui/UI/ButtonTextImagePage.cs
+++ b/Emgu.CV.Runtime/Maui/UI/ButtonTextImagePage.cs
@@ -173,7 +173,7 @@ namespace Emgu.CV.Platform.Maui.UI
             MessageLabel.FontFamily = bodyFont;
             MessageLabel.FontSize = 14;
             MessageLabel.TextColor = secondaryText;
-            MessageLabel.HorizontalTextAlignment = TextAlignment.Center;
+            MessageLabel.HorizontalTextAlignment = Microsoft.Maui.TextAlignment.Center;
             MessageLabel.HorizontalOptions = LayoutOptions.Center;
 
             _mainLayout.Spacing = 14;


### PR DESCRIPTION
Building the MAUI runtime for Android fails to compile:

```
ButtonTextImagePage.cs(176): error CS0104: 'TextAlignment' is an ambiguous reference between 'Microsoft.Maui.TextAlignment' and 'Android.Views.TextAlignment'
```

On Android both namespaces define `TextAlignment`. This qualifies the reference as `Microsoft.Maui.TextAlignment` so the Android build compiles (iOS/MacCatalyst were unaffected).