### PR TITLE
Android: disable KleidiCV to stop SVE crash on non-SVE devices

### DIFF
--- a/platforms/android/scripts/build.sh
+++ b/platforms/android/scripts/build.sh
@@ -112,6 +112,16 @@ BASE_CMAKE_FLAGS=(
     "-DCMAKE_C_FLAGS:STRING=-std=c11"
     "-DCMAKE_CXX_FLAGS_RELEASE:STRING=-g0 -O3"
     "-DCMAKE_C_FLAGS_RELEASE:STRING=-g0 -O3"
+    # Disable KleidiCV (ARM's optimized HAL, on by default for arm64 in
+    # OpenCV 5.0). It is the only component that compiles objects with
+    # -march=armv8-a+sve2, and under the whole-program (LTO) build that
+    # SVE2 codegen leaks into libwebp's WebPGetColorPalette. SVE is absent
+    # on the Android emulator and most real devices, so those instructions
+    # make libcvextern.so crash with SIGILL. Turning KleidiCV off removes
+    # every +sve2 object, so no SVE can be emitted anywhere. (Note:
+    # CPU_BASELINE_DISABLE=SVE does NOT help here — the SVE comes from
+    # KleidiCV/LTO, not OpenCV's own CPU baseline/dispatch.)
+    "-DWITH_KLEIDICV=OFF"
     "-DCMAKE_SHARED_LINKER_FLAGS:STRING=-Wl,--gc-sections, -Wl,--exclude-libs,All"
     "-DCMAKE_POLICY_DEFAULT_CMP0069=NEW"
     "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"


### PR DESCRIPTION
## Problem

The MAUI demo crashes with **SIGILL** on the Android arm64 emulator — and would on any device without SVE — right as `libcvextern.so` loads. The library contains SVE instructions in load-time code.

## Root cause

Disassembling the `.so` showed **every** SVE instruction was isolated to a single function: libwebp's `WebPGetColorPalette`. The `-march=armv8-a+sve2` codegen came solely from **KleidiCV** (ARM's optimized HAL, on by default for arm64 in OpenCV 5.0). Under the whole-program / LTO build, that SVE2 setting leaked into libwebp.

This is why the usual levers had no effect — the SVE never came from OpenCV's own CPU baseline/dispatch:
- `-mno-sve` is overridden by the per-file `+sve2` flags
- `-DCPU_BASELINE_DISABLE=SVE` only governs OpenCV's baseline, not KleidiCV

## Fix

Pass `-DWITH_KLEIDICV=OFF` in the Android `build.sh` cmake flags. This removes the only `+sve2` source, so no SVE is emitted anywhere, while keeping WebP/image support intact.

## Verification

- Rebuilt `libs/android/arm64-v8a/libcvextern.so`: `llvm-objdump -d | grep -cw rdvl` went from **99 → 0** (and 0 for all other SVE mnemonics).
- The MAUI demo app now **launches cleanly** on the arm64 emulator (full module list renders, no SIGILL).