### PR TITLE
MAUI demo: enable Barcode and QRCode Detection on iOS

### DIFF
--- a/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
@@ -330,9 +330,9 @@ namespace MauiDemoApp
 
             
             if (haveWechatQRCode && haveObjdetect
-              //TODO: WeChatQRCode detector doesn't work on iOS, probably a bug in iOS
-              //Will need to figure out why.
-              && (Microsoft.Maui.Devices.DeviceInfo.Platform != DevicePlatform.iOS)
+              //The WeChatQRCode detector now works on iOS since the model was
+              //switched from Caffe to ONNX (2026-06), so the previous
+              //iOS-only exclusion (added 2022) has been removed.
               )
             {
                 Button barcodeQrcodeDetectionButton = new Button();


### PR DESCRIPTION
## What

Removes the iOS-only exclusion on the **Barcode and QRCode Detection** tile in the MAUI demo, so it now appears and works on iOS (it was already available on Android).

## Why

The tile was hidden on iOS since 2022 because the `WeChatQRCode` detector didn't work there with the old Caffe models (there was a `//TODO: WeChatQRCode detector doesn't work on iOS` note guarding it). The model was switched from Caffe to **ONNX** in 2026-06 (`Emgu.CV.Models/Dnn/WeChatQRCodeDetector.cs`), and the detector now works on iOS — so the stale exclusion can be removed.

## Verification

Built and deployed to a physical iPhone 16 (iOS 26.5). The tile now shows on iOS, and device logs confirm both ONNX models load and run cleanly with no errors:

```
DNN/ONNX: loading ONNX v10 model ... nodes = 24    (detect)
DNN/ONNX: loading ONNX v10 model ... nodes = 180   (sr)
```

Barcode + QR detection renders correctly on the bundled test image. One-line change to the demo home screen; no library code touched.