### PR TITLE
MAUI demo: shared ModelShowcasePage template for detection modules

### DIFF
--- a/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
@@ -96,6 +96,10 @@ namespace MauiDemoApp
 
             bool haveCamera = true;
 
+            // Forward-declared here so the button Clicked handlers (which run
+            // after construction) can capture it; it is assigned further below.
+            Func<string, string> demoGlyph = null;
+
             /*
             if (haveOptFlow && haveCamera)
             {
@@ -167,70 +171,85 @@ namespace MauiDemoApp
 
             sceneTextDetectionButton.Clicked += (sender, args) =>
             {
-                ProcessAndRenderPage sceneTextDetectionPage = new ProcessAndRenderPage(
-                    new SceneTextDetector(),
-                    "Perform Scene Text Detection",
-                    "cars_license_plate.png",
-                    "This model is trained on MSRA-TD500, so it can detect both English and Chinese text instances.");
-                this.Navigation.PushAsync(sceneTextDetectionPage);
+                this.Navigation.PushAsync(new ModelShowcasePage(
+                    "Scene Text",
+                    "Find and read English and Chinese text in a photo.",
+                    demoGlyph("scene text"),
+                    () => new SceneTextDetector(),
+                    new[]
+                    {
+                        new ModelShowcasePage.Sample("cars_license_plate.png", "License plate", MaskRcnnPage.GlyphImage),
+                        new ModelShowcasePage.Sample("test_image.png", "Document", MaskRcnnPage.GlyphImage),
+                    },
+                    customProcess: (model, input) =>
+                    {
+                        // Scene text recognizes the words (DetectedObject.Label);
+                        // list them in the Results card, not just on the image.
+                        var std = (SceneTextDetector)model;
+                        DetectedObject[] objs = std.Detect(input);
+                        using Mat annotated = input.Clone();
+                        std.Render(annotated, objs);
+                        var items = new List<string>();
+                        foreach (DetectedObject o in objs)
+                            if (!String.IsNullOrWhiteSpace(o.Label))
+                                items.Add(o.Label);
+                        return (MaskRcnnPage.Encode(annotated), (IReadOnlyList<string>)items);
+                    }));
             };
             yoloButton.Clicked += (sender, args) =>
             {
-                ProcessAndRenderPage yoloPage = new ProcessAndRenderPage(
-                    new Yolo(),
-                    "Yolo Detection",
-                    "dog416.png",
-                    "");
-                Picker p = yoloPage.Picker;
-                p.Title = "Yolo model version";
-                p.IsVisible = true;
-                p.Items.Add("Yolo12N");
-                p.Items.Add("Yolo12S");
-                p.Items.Add("Yolo12M");
-                p.Items.Add("Yolo12L");
-                p.Items.Add("Yolo12X");
-                p.Items.Add("Yolo11N");
-                p.Items.Add("Yolo11S");
-                p.Items.Add("Yolo11M");
-                p.Items.Add("Yolo11L");
-                p.Items.Add("Yolo11X");
-                p.Items.Add("YoloV10N");
-                p.Items.Add("YoloV10S");
-                p.Items.Add("YoloV10M");
-                p.Items.Add("YoloV10B");
-                p.Items.Add("YoloV10L");
-                p.Items.Add("YoloV10X");
-                p.Items.Add("YoloV8N");
-                this.Navigation.PushAsync(yoloPage);
+                this.Navigation.PushAsync(new ModelShowcasePage(
+                    "YOLO",
+                    "Detect and label objects in a photo.",
+                    demoGlyph("yolo"),
+                    () => new Yolo(),
+                    new[]
+                    {
+                        new ModelShowcasePage.Sample("dog416.png", "Dog & bike", MaskRcnnPage.GlyphImage),
+                        new ModelShowcasePage.Sample("pedestrian.png", "Street", MaskRcnnPage.GlyphImage),
+                        new ModelShowcasePage.Sample("cars_license_plate.png", "Cars", MaskRcnnPage.GlyphImage),
+                    },
+                    pickerTitle: "Model version",
+                    pickerOptions: new[]
+                    {
+                        "Yolo12N", "Yolo12S", "Yolo12M", "Yolo12L", "Yolo12X",
+                        "Yolo11N", "Yolo11S", "Yolo11M", "Yolo11L", "Yolo11X",
+                        "YoloV10N", "YoloV10S", "YoloV10M", "YoloV10B", "YoloV10L", "YoloV10X",
+                        "YoloV8N",
+                    }));
             };
 
             superresButton.Clicked += (sender, args) =>
             {
-                ProcessAndRenderPage superresPage = new ProcessAndRenderPage(
-                    new Superres(),
-                    "Super resolution",
-                    "dog416.png",
-                    "");
-                Picker p = superresPage.Picker;
-                p.Title = "Super resolution version";
-                p.IsVisible = true;
-                //The model name must be the first token; the text after it is a
-                //description (Superres.Init only parses the leading token).
-                p.Items.Add("EdsrX2 - 2x, best quality, slowest, large download");
-                p.Items.Add("EdsrX3 - 3x, best quality, slowest, large download");
-                p.Items.Add("EdsrX4 - 4x, best quality, slowest, large download");
-                p.Items.Add("EspcnX2 - 2x, fast, small model");
-                p.Items.Add("EspcnX3 - 3x, fast, small model");
-                p.Items.Add("EspcnX4 - 4x, fast, small model");
-                p.Items.Add("FsrcnnX2 - 2x, fastest, tiny model");
-                p.Items.Add("FsrcnnX3 - 3x, fastest, tiny model");
-                p.Items.Add("FsrcnnX4 - 4x, fastest, tiny model");
-                p.Items.Add("LapsrnX2 - 2x, balanced speed and quality");
-                p.Items.Add("LapsrnX4 - 4x, balanced speed and quality");
-                p.Items.Add("LapsrnX8 - 8x, balanced speed and quality");
-
-
-                this.Navigation.PushAsync(superresPage);
+                // The model name must be the first token; the text after it is a
+                // description (Superres.Init only parses the leading token).
+                this.Navigation.PushAsync(new ModelShowcasePage(
+                    "Super Resolution",
+                    "Upscale a photo with a neural network.",
+                    demoGlyph("super resolution"),
+                    () => new Superres(),
+                    new[]
+                    {
+                        new ModelShowcasePage.Sample("dog416.png", "Dog & bike", MaskRcnnPage.GlyphImage),
+                        new ModelShowcasePage.Sample("lena.jpg", "Portrait", MaskRcnnPage.GlyphImage),
+                    },
+                    pickerTitle: "Super resolution version",
+                    pickerOptions: new[]
+                    {
+                        "EdsrX2 - 2x, best quality, slowest, large download",
+                        "EdsrX3 - 3x, best quality, slowest, large download",
+                        "EdsrX4 - 4x, best quality, slowest, large download",
+                        "EspcnX2 - 2x, fast, small model",
+                        "EspcnX3 - 3x, fast, small model",
+                        "EspcnX4 - 4x, fast, small model",
+                        "FsrcnnX2 - 2x, fastest, tiny model",
+                        "FsrcnnX3 - 3x, fastest, tiny model",
+                        "FsrcnnX4 - 4x, fastest, tiny model",
+                        "LapsrnX2 - 2x, balanced speed and quality",
+                        "LapsrnX4 - 4x, balanced speed and quality",
+                        "LapsrnX8 - 8x, balanced speed and quality",
+                    },
+                    hasCamera: false));
             };
 
             maskRcnnButton.IsVisible = haveDNN;
@@ -253,13 +272,16 @@ namespace MauiDemoApp
 
                 ocrButton.Clicked += (sender, args) =>
                 {
-                    ProcessAndRenderPage ocrPage = new ProcessAndRenderPage(
-                        new TesseractModel(),
-                        "Perform Text Detection",
-                        "test_image.png",
-                        "");
-                    ocrPage.HasCameraOption = false;
-                    this.Navigation.PushAsync(ocrPage);
+                    this.Navigation.PushAsync(new ModelShowcasePage(
+                        "Tesseract OCR",
+                        "Read printed text from an image.",
+                        demoGlyph("ocr"),
+                        () => new TesseractModel(),
+                        new[]
+                        {
+                            new ModelShowcasePage.Sample("test_image.png", "Document", MaskRcnnPage.GlyphImage),
+                        },
+                        hasCamera: false));
                 };
             } 
 
@@ -271,13 +293,13 @@ namespace MauiDemoApp
 
                 videoSurveillanceButton.Clicked += (sender, args) =>
                 {
-                    ProcessAndRenderPage videoPage = new ProcessAndRenderPage(
-                        new VideoSurveillanceModel(),
-                        "Open Camera",
+                    this.Navigation.PushAsync(new ModelShowcasePage(
+                        "Video Surveillance",
+                        "Track moving foreground objects from the camera.",
+                        demoGlyph("video"),
+                        () => new VideoSurveillanceModel(),
                         null,
-                        "");
-                    videoPage.HasCameraOption = true;
-                    this.Navigation.PushAsync(videoPage);
+                        hasCamera: true));
                 };
             }
 
@@ -290,24 +312,28 @@ namespace MauiDemoApp
 
                 faceDetectionButton.Clicked += (sender, args) =>
                 {
-                    ProcessAndRenderPage faceDetectionPage = new ProcessAndRenderPage(
-                        new FaceDetectionModel(),
-                        "Face Detection",
-                        "lena.jpg",
-                        "");
-                    Picker p = faceDetectionPage.Picker;
-                    p.Title = "Face detector";
-                    //Only offer the detectors whose required modules are
-                    //available. Yunet (objdetect + dnn) is the preferred
-                    //default, followed by the cascade classifier (objdetect).
+                    // Only offer the detectors whose required modules are
+                    // available. Yunet (objdetect + dnn) is the preferred
+                    // default, followed by the cascade classifier (objdetect).
+                    var detectors = new List<string>();
                     if (haveDNN)
-                        p.Items.Add(FaceDetectionModel.Yunet);
-                    p.Items.Add(FaceDetectionModel.CascadeClassifier);
+                        detectors.Add(FaceDetectionModel.Yunet);
+                    detectors.Add(FaceDetectionModel.CascadeClassifier);
                     if (haveFace && haveDNN)
-                        p.Items.Add(FaceDetectionModel.FaceLandmark);
-                    p.SelectedIndex = 0;
-                    p.IsVisible = p.Items.Count > 1;
-                    this.Navigation.PushAsync(faceDetectionPage);
+                        detectors.Add(FaceDetectionModel.FaceLandmark);
+
+                    this.Navigation.PushAsync(new ModelShowcasePage(
+                        "Face Detection",
+                        "Find faces in a photo.",
+                        demoGlyph("face"),
+                        () => new FaceDetectionModel(),
+                        new[]
+                        {
+                            new ModelShowcasePage.Sample("lena.jpg", "Portrait", MaskRcnnPage.GlyphImage),
+                            new ModelShowcasePage.Sample("pedestrian.png", "People", MaskRcnnPage.GlyphImage),
+                        },
+                        pickerTitle: "Face detector",
+                        pickerOptions: detectors.ToArray()));
                 };
 
                 Button pedestrianDetectionButton = new Button();
@@ -316,12 +342,15 @@ namespace MauiDemoApp
 
                 pedestrianDetectionButton.Clicked += (sender, args) =>
                 {
-                    ProcessAndRenderPage pedestrianDetectorPage = new ProcessAndRenderPage(
-                        new PedestrianDetector(),
-                        "Pedestrian detection",
-                        "pedestrian.png",
-                        "HOG pedestrian detection");
-                    this.Navigation.PushAsync(pedestrianDetectorPage);
+                    this.Navigation.PushAsync(new ModelShowcasePage(
+                        "Pedestrian Detection",
+                        "Detect people in a photo with HOG.",
+                        demoGlyph("pedestrian"),
+                        () => new PedestrianDetector(),
+                        new[]
+                        {
+                            new ModelShowcasePage.Sample("pedestrian.png", "Street", MaskRcnnPage.GlyphImage),
+                        }));
                 };
 
             }
@@ -340,16 +369,15 @@ namespace MauiDemoApp
                 buttonList.Add(barcodeQrcodeDetectionButton);
                 barcodeQrcodeDetectionButton.Clicked += (sender, args) =>
                 {
-                    BarcodeDetectorModel barcodeDetector = new BarcodeDetectorModel();
-                    WeChatQRCodeDetector qrcodeDetector = new WeChatQRCodeDetector();
-                    CombinedModel combinedModel = new CombinedModel(barcodeDetector, qrcodeDetector);
-
-                    ProcessAndRenderPage barcodeQrcodeDetectionPage = new ProcessAndRenderPage(
-                        combinedModel,
-                        "Perform Barcode and QRCode Detection",
-                        "qrcode_barcode.png",
-                        "");
-                    this.Navigation.PushAsync(barcodeQrcodeDetectionPage);
+                    this.Navigation.PushAsync(new ModelShowcasePage(
+                        "Barcode & QRCode",
+                        "Detect and decode barcodes and QR codes.",
+                        demoGlyph("barcode"),
+                        () => new CombinedModel(new BarcodeDetectorModel(), new WeChatQRCodeDetector()),
+                        new[]
+                        {
+                            new ModelShowcasePage.Sample("qrcode_barcode.png", "QR & barcode", MaskRcnnPage.GlyphImage),
+                        }));
                 };
             }
 
@@ -419,7 +447,7 @@ namespace MauiDemoApp
                 HorizontalOptions = LayoutOptions.Center
             };
 
-            Func<string, string> demoGlyph = (text) =>
+            demoGlyph = (text) =>
             {
                 string t = (text ?? "").ToLowerInvariant();
                 if (t.Contains("shape")) return "";                              // crop_free

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
@@ -194,7 +194,8 @@ namespace MauiDemoApp
                             if (!String.IsNullOrWhiteSpace(o.Label))
                                 items.Add(o.Label);
                         return (MaskRcnnPage.Encode(annotated), (IReadOnlyList<string>)items);
-                    }));
+                    },
+                    about: "Finds text anywhere in a photo — signs, labels, plates — and reads it, even at odd angles."));
             };
             yoloButton.Clicked += (sender, args) =>
             {
@@ -216,7 +217,8 @@ namespace MauiDemoApp
                         "Yolo11N", "Yolo11S", "Yolo11M", "Yolo11L", "Yolo11X",
                         "YoloV10N", "YoloV10S", "YoloV10M", "YoloV10B", "YoloV10L", "YoloV10X",
                         "YoloV8N",
-                    }));
+                    },
+                    about: "Fast, general-purpose object detection: one neural network finds and labels every object in a single pass — hence \"You Only Look Once.\""));
             };
 
             superresButton.Clicked += (sender, args) =>
@@ -249,7 +251,8 @@ namespace MauiDemoApp
                         "LapsrnX4 - 4x, balanced speed and quality",
                         "LapsrnX8 - 8x, balanced speed and quality",
                     },
-                    hasCamera: false));
+                    hasCamera: false,
+                    about: "Uses a neural network to upscale and sharpen an image, reconstructing fine detail (2×–8×)."));
             };
 
             if (haveDNN)
@@ -305,7 +308,8 @@ namespace MauiDemoApp
                         {
                             new ModelShowcasePage.Sample("test_image.png", "Document", MaskRcnnPage.GlyphImage),
                         },
-                        hasCamera: false));
+                        hasCamera: false,
+                        about: "Classic document OCR — reads printed text from an image into editable text."));
                 };
             }
 
@@ -344,7 +348,8 @@ namespace MauiDemoApp
                                     items.Add(r.Text);
                             }
                             return (MaskRcnnPage.Encode(annotated), (IReadOnlyList<string>)items);
-                        }));
+                        },
+                        about: "A newer, more accurate OCR engine (PP-OCRv4) that finds and reads text — strong on dense and multilingual text."));
                 };
             }
 
@@ -363,7 +368,8 @@ namespace MauiDemoApp
                         demoGlyph("video"),
                         () => new VideoSurveillanceModel(),
                         null,
-                        hasCamera: true));
+                        hasCamera: true,
+                        about: "Learns the static background from the camera, then flags and tracks anything that moves."));
                 };
             }
 
@@ -397,7 +403,8 @@ namespace MauiDemoApp
                             new ModelShowcasePage.Sample("pedestrian.png", "People", MaskRcnnPage.GlyphImage),
                         },
                         pickerTitle: "Face detector",
-                        pickerOptions: detectors.ToArray()));
+                        pickerOptions: detectors.ToArray(),
+                        about: "Finds faces in a photo; pick the engine — Yunet, a Haar cascade, or one that also marks facial landmarks."));
                 };
 
                 Button pedestrianDetectionButton = new Button();
@@ -414,7 +421,8 @@ namespace MauiDemoApp
                         new[]
                         {
                             new ModelShowcasePage.Sample("pedestrian.png", "Street", MaskRcnnPage.GlyphImage),
-                        }));
+                        },
+                        about: "Detects people using HOG — a classic, lightweight person-finder for surveillance and counting."));
                 };
 
             }
@@ -441,7 +449,8 @@ namespace MauiDemoApp
                         new[]
                         {
                             new ModelShowcasePage.Sample("qrcode_barcode.png", "QR & barcode", MaskRcnnPage.GlyphImage),
-                        }));
+                        },
+                        about: "Detects and decodes barcodes and QR codes, returning the value they encode."));
                 };
             }
 

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
@@ -317,12 +317,34 @@ namespace MauiDemoApp
 
                 paddleOcrButton.Clicked += (sender, args) =>
                 {
-                    ProcessAndRenderPage paddleOcrPage = new ProcessAndRenderPage(
-                        new PaddleOCR(),
+                    this.Navigation.PushAsync(new ModelShowcasePage(
                         "PaddleOCR",
-                        "cars_license_plate.png",
-                        "PP-OCRv4 text detection and recognition");
-                    this.Navigation.PushAsync(paddleOcrPage);
+                        "Detect and read text with PP-OCRv4.",
+                        demoGlyph("ocr"),
+                        () => new PaddleOCR(),
+                        new[]
+                        {
+                            new ModelShowcasePage.Sample("cars_license_plate.png", "License plate", MaskRcnnPage.GlyphImage),
+                            new ModelShowcasePage.Sample("test_image.png", "Document", MaskRcnnPage.GlyphImage),
+                        },
+                        customProcess: (model, input) =>
+                        {
+                            // PP-OCRv4 detects + reads text: draw the regions and
+                            // list the recognized text in the Results card.
+                            var paddle = (PaddleOCR)model;
+                            PaddleOCR.OcrResult[] results = paddle.Recognize(input);
+                            using Mat annotated = input.Clone();
+                            var items = new List<string>();
+                            foreach (PaddleOCR.OcrResult r in results)
+                            {
+                                System.Drawing.Point[] corners = Array.ConvertAll(r.Region, System.Drawing.Point.Round);
+                                using (var vp = new Emgu.CV.Util.VectorOfPoint(corners))
+                                    CvInvoke.Polylines(annotated, vp, true, new Emgu.CV.Structure.MCvScalar(0, 0, 255), 2);
+                                if (!String.IsNullOrWhiteSpace(r.Text))
+                                    items.Add(r.Text);
+                            }
+                            return (MaskRcnnPage.Encode(annotated), (IReadOnlyList<string>)items);
+                        }));
                 };
             }
 

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/MaskRcnnPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/MaskRcnnPage.cs
@@ -261,7 +261,11 @@ namespace MauiDemoApp
             {
                 Spacing = 18,
                 Padding = new Thickness(20, 16, 20, 28),
-                Children = { header, inputCard, buttonStack, resultsCard }
+                Children =
+                {
+                    header, inputCard, buttonStack, resultsCard,
+                    ModelShowcasePage.BuildAboutCard("Detects objects and traces the exact outline (mask) of each one, with a label and confidence score.")
+                }
             };
 
             // ---------- Loading overlay ----------

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
@@ -63,6 +63,10 @@ namespace MauiDemoApp
         // generic message string.
         private readonly Func<IProcessAndRenderModel, Mat, (byte[] png, IReadOnlyList<string> items)> _customProcess;
 
+        // Optional "About this module" description, shown as one paragraph in a
+        // collapsible card at the bottom of the page.
+        private readonly string _about;
+
         private IProcessAndRenderModel _model;
         private Mat _currentImage;
         private Mat _renderBuffer;
@@ -114,10 +118,12 @@ namespace MauiDemoApp
             string pickerTitle = null,
             string[] pickerOptions = null,
             bool hasCamera = true,
-            Func<IProcessAndRenderModel, Mat, (byte[] png, IReadOnlyList<string> items)> customProcess = null)
+            Func<IProcessAndRenderModel, Mat, (byte[] png, IReadOnlyList<string> items)> customProcess = null,
+            string about = null)
         {
             _modelFactory = modelFactory;
             _customProcess = customProcess;
+            _about = about;
             _samples = samples ?? Array.Empty<Sample>();
             _pickerTitle = pickerTitle;
             _pickerOptions = pickerOptions;
@@ -327,6 +333,10 @@ namespace MauiDemoApp
                 Content = new VerticalStackLayout { Spacing = 12, Children = { resultsHeader, _emptyState, _resultsBody } }
             };
             pageChildren.Children.Add(resultsCard);
+
+            // ---------- About this module (collapsible) ----------
+            if (!string.IsNullOrWhiteSpace(_about))
+                pageChildren.Children.Add(BuildAboutCard(_about));
 
             // ---------- Loading overlay ----------
             _loadingIndicator = new ActivityIndicator { IsRunning = false, Color = MaskRcnnPage.Accent, WidthRequest = 44, HeightRequest = 44, HorizontalOptions = LayoutOptions.Center };
@@ -778,6 +788,41 @@ namespace MauiDemoApp
             t.Tapped += (s, e) => onTap();
             cb.GestureRecognizers.Add(t);
             return cb;
+        }
+
+        // ---------- About this module (collapsible one-paragraph card) ----------
+        // Static + self-contained (its own toggle state is captured in the tap
+        // closure) so the bespoke pages (Mask R-CNN, Shape Detection) can reuse it.
+        internal static View BuildAboutCard(string about)
+        {
+            var titleLabel = new Label { Text = "About this module", FontFamily = MaskRcnnPage.TitleFont, FontSize = 17, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center };
+            var chevron = MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphChevronRight, MaskRcnnPage.SecondaryText, 22);
+
+            var headerRow = new Grid { ColumnDefinitions = { new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            headerRow.Add(titleLabel, 0, 0);
+            headerRow.Add(chevron, 1, 0);
+
+            var details = new VerticalStackLayout { IsVisible = false, Margin = new Thickness(0, 12, 0, 2) };
+            details.Children.Add(new Label { Text = about, FontFamily = MaskRcnnPage.BodyFont, FontSize = 15, TextColor = MaskRcnnPage.SecondaryText });
+
+            bool expanded = false;
+            var tap = new TapGestureRecognizer();
+            tap.Tapped += async (s, e) =>
+            {
+                expanded = !expanded;
+                details.IsVisible = expanded;
+                await chevron.RotateTo(expanded ? 90 : 0, 180, Easing.CubicOut);
+            };
+            headerRow.GestureRecognizers.Add(tap);
+
+            return new Border
+            {
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(22) },
+                Padding = new Thickness(16),
+                Content = new VerticalStackLayout { Children = { headerRow, details } }
+            };
         }
 
         private Border PillButton(string glyph, string text, EventHandler onTap)

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
@@ -1,0 +1,1026 @@
+//----------------------------------------------------------------------------
+//  Copyright (C) 2004-2026 by EMGU Corporation. All rights reserved.
+//----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+using Emgu.CV;
+using Emgu.CV.CvEnum;
+using Emgu.CV.Models;
+using Emgu.CV.Structure;
+
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Media;
+using Microsoft.Maui.Storage;
+
+namespace MauiDemoApp
+{
+    /// <summary>
+    /// A reusable, on-theme showcase page for any <see cref="IProcessAndRenderModel"/>.
+    /// It reproduces the bespoke Mask R-CNN experience (curated sample photos, a
+    /// photo/camera picker, a styled results card and — on iOS — a full-screen
+    /// live camera page) for every other detection module, without duplicating the
+    /// layout. Each module only supplies a title, subtitle, glyph, a factory for its
+    /// model, its sample photos and (optionally) a version picker.
+    ///
+    /// Unlike the bespoke Mask R-CNN page (which renders a structured per-object
+    /// list), this base uses the common <see cref="IProcessAndRenderModel.ProcessAndRender"/>
+    /// contract: it shows the annotated image plus the message string the model
+    /// returns. That works uniformly for every module.
+    /// </summary>
+    public class ModelShowcasePage : ContentPage
+    {
+        /// <summary>A curated sample photo shown in the Change Photo sheet.</summary>
+        public sealed class Sample
+        {
+            public string File { get; }
+            public string Name { get; }
+            public string Glyph { get; }
+            public Sample(string file, string name, string glyph)
+            {
+                File = file; Name = name; Glyph = glyph;
+            }
+        }
+
+        private readonly Func<IProcessAndRenderModel> _modelFactory;
+        private readonly Sample[] _samples;
+        private readonly string _pickerTitle;
+        private readonly string[] _pickerOptions;
+        private readonly bool _hasCamera;
+        private readonly bool _hasStillImage;
+        private readonly string _title;
+
+        // Optional per-module hook: given the model and input image, produce the
+        // annotated PNG plus a list of textual result items (e.g. recognized
+        // words). When set, the Results card lists these rows instead of the
+        // generic message string.
+        private readonly Func<IProcessAndRenderModel, Mat, (byte[] png, IReadOnlyList<string> items)> _customProcess;
+
+        private IProcessAndRenderModel _model;
+        private Mat _currentImage;
+        private Mat _renderBuffer;
+        private bool _busy;
+        private bool _defaultLoaded;
+        private byte[] _lastResultPng;
+        private int _pickerIndex = -1;
+
+        // Runtime UI.
+        private readonly Image _previewImage;
+        private readonly VerticalStackLayout _resultsBody;
+        private readonly VerticalStackLayout _emptyState;
+        private readonly Label _resultsStatusLabel;
+        private readonly Image _resultsCheck;
+        private readonly Label _resultsTimeLabel;
+        private readonly Label _resultsMessage;
+        private readonly Button _detectButton;
+        private readonly Button _liveButton;
+        private readonly Grid _loadingOverlay;
+        private readonly Label _loadingLabel;
+        private readonly ActivityIndicator _loadingIndicator;
+        private readonly Microsoft.Maui.Controls.Picker _versionPicker;
+
+        // Change Photo sheet.
+        private readonly Grid _sheetOverlay;
+        private readonly BoxView _sheetScrim;
+        private readonly Border _sheetCard;
+        private readonly VerticalStackLayout _sheetList;
+        private TaskCompletionSource<string> _sheetTcs;
+        private bool _sheetAnimating;
+
+        /// <summary>
+        /// Create a showcase page for a model.
+        /// </summary>
+        /// <param name="title">Module name, shown in the header.</param>
+        /// <param name="subtitle">One-line description under the title.</param>
+        /// <param name="glyph">Material Symbols glyph for the header tile.</param>
+        /// <param name="modelFactory">Creates a fresh model instance (used by both the still page and the live page).</param>
+        /// <param name="samples">Curated sample photos. Pass null/empty for a camera-only module.</param>
+        /// <param name="pickerTitle">Optional label for a version picker.</param>
+        /// <param name="pickerOptions">Optional version options, passed to Init as the selection string.</param>
+        /// <param name="hasCamera">Whether the module supports live camera detection.</param>
+        public ModelShowcasePage(
+            string title,
+            string subtitle,
+            string glyph,
+            Func<IProcessAndRenderModel> modelFactory,
+            Sample[] samples,
+            string pickerTitle = null,
+            string[] pickerOptions = null,
+            bool hasCamera = true,
+            Func<IProcessAndRenderModel, Mat, (byte[] png, IReadOnlyList<string> items)> customProcess = null)
+        {
+            _modelFactory = modelFactory;
+            _customProcess = customProcess;
+            _samples = samples ?? Array.Empty<Sample>();
+            _pickerTitle = pickerTitle;
+            _pickerOptions = pickerOptions;
+            _hasCamera = hasCamera;
+            _hasStillImage = _samples.Length > 0;
+            _title = title;
+
+            _model = modelFactory();
+
+            Title = title;
+            BackgroundColor = MaskRcnnPage.PageBackground;
+            Shell.SetNavBarIsVisible(this, false);
+
+            // ---------- Header ----------
+            var headerTile = new Border
+            {
+                WidthRequest = 64,
+                HeightRequest = 64,
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(18) },
+                VerticalOptions = LayoutOptions.Start,
+                Content = MaskRcnnPage.MakeIcon(glyph, MaskRcnnPage.Accent, 32)
+            };
+            var titleLabel = new Label { Text = title, FontFamily = MaskRcnnPage.TitleFont, FontSize = 30, TextColor = MaskRcnnPage.PrimaryText };
+            var subtitleLabel = new Label
+            {
+                Text = subtitle,
+                FontFamily = MaskRcnnPage.BodyFont,
+                FontSize = 15,
+                TextColor = MaskRcnnPage.SecondaryText,
+                Margin = new Thickness(0, 2, 0, 0)
+            };
+            var titleStack = new VerticalStackLayout { VerticalOptions = LayoutOptions.Center, Children = { titleLabel, subtitleLabel } };
+
+            var backButton = CircleButton(MaskRcnnPage.GlyphChevronLeft, async () => await Navigation.PopAsync());
+            var infoButton = CircleButton(MaskRcnnPage.GlyphInfo, async () => await Navigation.PushAsync(new AboutPage()));
+
+            var topRow = new Grid { ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            topRow.Add(backButton, 0, 0);
+            topRow.Add(infoButton, 2, 0);
+
+            var headerBody = new Grid
+            {
+                ColumnSpacing = 16,
+                Margin = new Thickness(0, 12, 0, 0),
+                ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star) }
+            };
+            headerBody.Add(headerTile, 0, 0);
+            headerBody.Add(titleStack, 1, 0);
+
+            var header = new VerticalStackLayout { Children = { topRow, headerBody } };
+
+            var pageChildren = new VerticalStackLayout
+            {
+                Spacing = 18,
+                Padding = new Thickness(20, 16, 20, 28),
+                Children = { header }
+            };
+
+            // ---------- Input Image card (only for still-image modules) ----------
+            _previewImage = new Image { Aspect = Aspect.AspectFit, HeightRequest = 340 };
+            if (_hasStillImage)
+            {
+                var inputTitle = new Label { Text = "Input Image", FontFamily = MaskRcnnPage.TitleFont, FontSize = 19, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center };
+                var changePhoto = PillButton(MaskRcnnPage.GlyphImage, "Change Photo", OnChangePhoto);
+                var inputHeader = new Grid { ColumnDefinitions = { new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+                inputHeader.Add(inputTitle, 0, 0);
+                inputHeader.Add(changePhoto, 1, 0);
+
+                var previewFrame = new Border
+                {
+                    BackgroundColor = MaskRcnnPage.ImageBackground,
+                    Stroke = MaskRcnnPage.RowBorder,
+                    StrokeThickness = 1,
+                    Padding = new Thickness(10),
+                    StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(16) },
+                    Content = _previewImage
+                };
+                var previewTap = new TapGestureRecognizer();
+                previewTap.Tapped += async (s, e) =>
+                {
+                    if (_lastResultPng != null)
+                        await Navigation.PushModalAsync(new FullScreenImagePage(_lastResultPng, title));
+                };
+                previewFrame.GestureRecognizers.Add(previewTap);
+
+                var inputChildren = new VerticalStackLayout { Spacing = 14, Children = { inputHeader, previewFrame } };
+
+                // Optional version picker.
+                if (_pickerOptions != null && _pickerOptions.Length > 0)
+                {
+                    _versionPicker = new Microsoft.Maui.Controls.Picker
+                    {
+                        Title = _pickerTitle,
+                        FontFamily = MaskRcnnPage.BodyFont,
+                        TextColor = MaskRcnnPage.PrimaryText,
+                        TitleColor = MaskRcnnPage.SecondaryText
+                    };
+                    foreach (string opt in _pickerOptions)
+                        _versionPicker.Items.Add(opt);
+                    _versionPicker.SelectedIndex = 0;
+                    _pickerIndex = 0;
+                    _versionPicker.SelectedIndexChanged += OnPickerChanged;
+
+                    var pickerFrame = new Border
+                    {
+                        BackgroundColor = MaskRcnnPage.ImageBackground,
+                        Stroke = MaskRcnnPage.RowBorder,
+                        StrokeThickness = 1,
+                        Padding = new Thickness(12, 2),
+                        StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(14) },
+                        Content = _versionPicker
+                    };
+                    inputChildren.Children.Add(pickerFrame);
+                }
+
+                var inputCard = new Border
+                {
+                    BackgroundColor = MaskRcnnPage.CardBackground,
+                    Stroke = Colors.Transparent,
+                    StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(22) },
+                    Padding = new Thickness(16),
+                    Content = inputChildren
+                };
+                pageChildren.Children.Add(inputCard);
+            }
+
+            // ---------- Buttons ----------
+            _detectButton = new Button
+            {
+                Text = _hasStillImage ? "Detect Image" : "Open Camera",
+                FontFamily = MaskRcnnPage.TitleFont,
+                FontSize = 17,
+                BackgroundColor = MaskRcnnPage.Accent,
+                TextColor = Colors.White,
+                CornerRadius = 16,
+                HeightRequest = 56,
+                ImageSource = new FontImageSource { FontFamily = MaskRcnnPage.IconFont, Glyph = _hasStillImage ? MaskRcnnPage.GlyphPlay : MaskRcnnPage.GlyphVideo, Color = Colors.White, Size = 20 },
+                ContentLayout = new Button.ButtonContentLayout(Button.ButtonContentLayout.ImagePosition.Left, 8)
+            };
+            if (_hasStillImage)
+                _detectButton.Clicked += OnDetectClicked;
+            else
+                _detectButton.Clicked += OnLiveDetection;
+
+            var buttonChildren = new VerticalStackLayout { Spacing = 12, Children = { _detectButton } };
+
+            // A separate Live button only makes sense when the primary action is a
+            // still-image detect and the module also supports the camera.
+            _liveButton = new Button
+            {
+                Text = "Live Detection",
+                FontFamily = MaskRcnnPage.TitleFont,
+                FontSize = 16,
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                TextColor = MaskRcnnPage.Accent,
+                BorderColor = MaskRcnnPage.Accent,
+                BorderWidth = 1,
+                CornerRadius = 16,
+                HeightRequest = 52,
+                ImageSource = new FontImageSource { FontFamily = MaskRcnnPage.IconFont, Glyph = MaskRcnnPage.GlyphVideo, Color = MaskRcnnPage.Accent, Size = 20 },
+                ContentLayout = new Button.ButtonContentLayout(Button.ButtonContentLayout.ImagePosition.Left, 8)
+            };
+            _liveButton.Clicked += OnLiveDetection;
+            if (_hasStillImage && _hasCamera)
+                buttonChildren.Children.Add(_liveButton);
+            pageChildren.Children.Add(buttonChildren);
+
+            // ---------- Results card ----------
+            var resultsTitle = new Label { Text = "Results", FontFamily = MaskRcnnPage.TitleFont, FontSize = 19, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center };
+
+            _resultsStatusLabel = new Label { Text = "Ready", FontFamily = MaskRcnnPage.BodyFont, FontSize = 14, TextColor = MaskRcnnPage.SecondaryText, VerticalOptions = LayoutOptions.Center };
+            _resultsCheck = MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphCheck, Color.FromArgb("#2BA84A"), 18);
+            _resultsCheck.IsVisible = false;
+            _resultsTimeLabel = new Label { Text = "", FontFamily = MaskRcnnPage.BodyFont, FontSize = 12, TextColor = MaskRcnnPage.SecondaryText, IsVisible = false, HorizontalTextAlignment = TextAlignment.End };
+            var statusRow = new HorizontalStackLayout { Spacing = 6, HorizontalOptions = LayoutOptions.End, Children = { _resultsStatusLabel, _resultsCheck } };
+            var statusStack = new VerticalStackLayout { HorizontalOptions = LayoutOptions.End, VerticalOptions = LayoutOptions.Center, Children = { statusRow, _resultsTimeLabel } };
+
+            var resultsHeader = new Grid { ColumnDefinitions = { new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            resultsHeader.Add(resultsTitle, 0, 0);
+            resultsHeader.Add(statusStack, 1, 0);
+
+            _emptyState = new VerticalStackLayout
+            {
+                Spacing = 6,
+                Padding = new Thickness(0, 18, 0, 8),
+                HorizontalOptions = LayoutOptions.Center,
+                Children =
+                {
+                    MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphImage, Color.FromArgb("#C2C7D6"), 40),
+                    new Label { Text = "No results yet", FontFamily = MaskRcnnPage.TitleFont, FontSize = 15, TextColor = MaskRcnnPage.PrimaryText, HorizontalTextAlignment = TextAlignment.Center },
+                    new Label { Text = _hasStillImage ? "Tap the button above to analyze." : "Open the camera to start.", FontFamily = MaskRcnnPage.BodyFont, FontSize = 13, TextColor = MaskRcnnPage.SecondaryText, HorizontalTextAlignment = TextAlignment.Center }
+                }
+            };
+
+            _resultsMessage = new Label { FontFamily = MaskRcnnPage.BodyFont, FontSize = 15, TextColor = MaskRcnnPage.PrimaryText, IsVisible = false };
+            _resultsBody = new VerticalStackLayout { Spacing = 0, Children = { _resultsMessage } };
+
+            var resultsCard = new Border
+            {
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(22) },
+                Padding = new Thickness(16),
+                Content = new VerticalStackLayout { Spacing = 12, Children = { resultsHeader, _emptyState, _resultsBody } }
+            };
+            pageChildren.Children.Add(resultsCard);
+
+            // ---------- Loading overlay ----------
+            _loadingIndicator = new ActivityIndicator { IsRunning = false, Color = MaskRcnnPage.Accent, WidthRequest = 44, HeightRequest = 44, HorizontalOptions = LayoutOptions.Center };
+            _loadingLabel = new Label { Text = "Working…", FontFamily = MaskRcnnPage.BodyFont, FontSize = 15, TextColor = MaskRcnnPage.PrimaryText, HorizontalOptions = LayoutOptions.Center, HorizontalTextAlignment = TextAlignment.Center };
+            var loadingCard = new Border
+            {
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                Padding = new Thickness(28, 22),
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(20) },
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.Center,
+                Content = new VerticalStackLayout { Spacing = 14, WidthRequest = 240, Children = { _loadingIndicator, _loadingLabel } }
+            };
+            _loadingOverlay = new Grid { IsVisible = false, BackgroundColor = Color.FromArgb("#B3EEF1F8"), Children = { loadingCard } };
+
+            // ---------- Change Photo sheet ----------
+            _sheetList = new VerticalStackLayout { Spacing = 0 };
+            _sheetCard = new Border
+            {
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(28, 28, 0, 0) },
+                Padding = new Thickness(20, 8, 20, 60),
+                Margin = new Thickness(0, 0, 0, -40),
+                VerticalOptions = LayoutOptions.End,
+                Content = _sheetList
+            };
+            _sheetScrim = new BoxView { Color = Color.FromArgb("#66000000"), Opacity = 0, Margin = new Thickness(0, -120, 0, -120) };
+            var sheetScrimTap = new TapGestureRecognizer();
+            sheetScrimTap.Tapped += (s, e) => CloseSheet(null);
+            _sheetScrim.GestureRecognizers.Add(sheetScrimTap);
+            _sheetOverlay = new Grid { IsVisible = false, Children = { _sheetScrim, _sheetCard } };
+            if (_hasStillImage)
+                BuildSheet();
+
+            Content = new Grid { Children = { new Microsoft.Maui.Controls.ScrollView { Content = pageChildren }, _loadingOverlay, _sheetOverlay } };
+        }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            if (_hasStillImage && !_defaultLoaded)
+            {
+                _defaultLoaded = true;
+                Mat m = await LoadSampleAsync(0);
+                if (m != null)
+                    SetCurrentImage(m);
+            }
+        }
+
+        protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+        {
+            base.OnNavigatedFrom(args);
+            if (!Navigation.NavigationStack.Contains(this) && !Navigation.ModalStack.Contains(this))
+            {
+                _currentImage?.Dispose();
+                _currentImage = null;
+                _renderBuffer?.Dispose();
+                _renderBuffer = null;
+                _model?.Dispose();
+                _model = null;
+            }
+        }
+
+        // ---------- Version picker ----------
+
+        private void OnPickerChanged(object sender, EventArgs e)
+        {
+            if (_versionPicker.SelectedIndex == _pickerIndex)
+                return;
+            _pickerIndex = _versionPicker.SelectedIndex;
+            // A different version means the model must be re-initialized.
+            _model?.Clear();
+            ResetResults();
+        }
+
+        private string CurrentPickerSelection =>
+            (_versionPicker != null && _versionPicker.SelectedIndex >= 0)
+                ? _versionPicker.Items[_versionPicker.SelectedIndex]
+                : null;
+
+        // ---------- Image sources ----------
+
+        private async void OnChangePhoto(object sender, EventArgs e)
+        {
+            string action = await OpenChangePhotoSheet();
+            if (string.IsNullOrEmpty(action))
+                return;
+
+            if (action.StartsWith("sample:"))
+            {
+                int idx = int.Parse(action.Substring("sample:".Length));
+                Mat sm = await LoadSampleAsync(idx);
+                if (sm != null) SetCurrentImage(sm);
+                return;
+            }
+
+            try
+            {
+                FileResult file = action == "camera"
+                    ? await MediaPicker.Default.CapturePhotoAsync()
+                    : await MediaPicker.Default.PickPhotoAsync();
+                if (file == null)
+                    return;
+
+                SetBusy(true, "Loading photo…");
+                using Stream stream = await file.OpenReadAsync();
+                using MemoryStream ms = new MemoryStream();
+                await stream.CopyToAsync(ms);
+                Mat m = new Mat();
+                CvInvoke.Imdecode(ms.ToArray(), ImreadModes.ColorBgr, m);
+                SetBusy(false);
+                if (m.IsEmpty)
+                {
+                    m.Dispose();
+                    await DisplayAlert("Photo", "That file could not be read as an image.", "OK");
+                    return;
+                }
+                SetCurrentImage(MaskRcnnPage.Downscale(m, 1024));
+            }
+            catch (Exception ex)
+            {
+                SetBusy(false);
+                await DisplayAlert("Could not load photo", ex.Message, "OK");
+            }
+        }
+
+        // ---------- Change Photo bottom sheet ----------
+
+        private void BuildSheet()
+        {
+            _sheetList.Children.Clear();
+            _sheetList.Children.Add(new BoxView { WidthRequest = 40, HeightRequest = 5, CornerRadius = 3, Color = Color.FromArgb("#D5D8E0"), HorizontalOptions = LayoutOptions.Center, Margin = new Thickness(0, 10, 0, 6) });
+            _sheetList.Children.Add(new Label { Text = "Change Photo", FontFamily = MaskRcnnPage.TitleFont, FontSize = 20, TextColor = MaskRcnnPage.PrimaryText, HorizontalOptions = LayoutOptions.Center, Margin = new Thickness(0, 0, 0, 6) });
+
+            _sheetList.Children.Add(SheetSection("SAMPLE IMAGES"));
+            for (int i = 0; i < _samples.Length; i++)
+                _sheetList.Children.Add(SheetRow(_samples[i].Glyph, _samples[i].Name, $"sample:{i}", i < _samples.Length - 1));
+
+            _sheetList.Children.Add(SheetSection("YOUR PHOTOS"));
+            bool cam = MediaPicker.Default.IsCaptureSupported;
+            _sheetList.Children.Add(SheetRow(MaskRcnnPage.GlyphImage, "Photo Library", "library", cam));
+            if (cam)
+                _sheetList.Children.Add(SheetRow(MaskRcnnPage.GlyphCamera, "Take Photo", "camera", false));
+
+            var cancelLabel = new Label { Text = "Cancel", FontFamily = MaskRcnnPage.TitleFont, FontSize = 17, TextColor = MaskRcnnPage.Accent, HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
+            var cancel = new Border { BackgroundColor = Color.FromArgb("#F2F2F7"), Stroke = Colors.Transparent, StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(14) }, HeightRequest = 52, Margin = new Thickness(0, 14, 0, 0), Content = cancelLabel };
+            var cancelTap = new TapGestureRecognizer();
+            cancelTap.Tapped += (s, e) => CloseSheet(null);
+            cancel.GestureRecognizers.Add(cancelTap);
+            _sheetList.Children.Add(cancel);
+        }
+
+        private static View SheetSection(string text) => new Label
+        {
+            Text = text,
+            FontFamily = MaskRcnnPage.TitleFont,
+            FontSize = 12,
+            TextColor = MaskRcnnPage.SecondaryText,
+            CharacterSpacing = 1.2,
+            Margin = new Thickness(2, 16, 0, 2)
+        };
+
+        private View SheetRow(string glyph, string text, string value, bool divider)
+        {
+            var grid = new Grid
+            {
+                Padding = new Thickness(2, 14),
+                ColumnSpacing = 16,
+                ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star) }
+            };
+            grid.Add(MaskRcnnPage.MakeIcon(glyph, MaskRcnnPage.Accent, 26), 0, 0);
+            grid.Add(new Label { Text = text, FontFamily = MaskRcnnPage.BodyFont, FontSize = 17, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center }, 1, 0);
+            var tap = new TapGestureRecognizer();
+            tap.Tapped += (s, e) => CloseSheet(value);
+            grid.GestureRecognizers.Add(tap);
+
+            var stack = new VerticalStackLayout();
+            stack.Children.Add(grid);
+            if (divider)
+                stack.Children.Add(new BoxView { HeightRequest = 1, Color = MaskRcnnPage.RowBorder, Margin = new Thickness(42, 0, 0, 0) });
+            return stack;
+        }
+
+        private Task<string> OpenChangePhotoSheet()
+        {
+            _sheetTcs = new TaskCompletionSource<string>();
+            _sheetOverlay.IsVisible = true;
+            _sheetScrim.Opacity = 0;
+            _sheetCard.TranslationY = 700;
+            _ = Task.WhenAll(
+                _sheetScrim.FadeTo(1, 220, Easing.CubicOut),
+                _sheetCard.TranslateTo(0, 0, 260, Easing.CubicOut));
+            return _sheetTcs.Task;
+        }
+
+        private async void CloseSheet(string value)
+        {
+            if (_sheetAnimating)
+                return;
+            _sheetAnimating = true;
+            await Task.WhenAll(
+                _sheetScrim.FadeTo(0, 180, Easing.CubicIn),
+                _sheetCard.TranslateTo(0, 700, 220, Easing.CubicIn));
+            _sheetOverlay.IsVisible = false;
+            _sheetAnimating = false;
+            _sheetTcs?.TrySetResult(value);
+        }
+
+        private async Task<Mat> LoadSampleAsync(int idx)
+        {
+            try
+            {
+                byte[] bytes = await MaskRcnnPage.ReadAppFileAsync(_samples[idx].File);
+                Mat m = new Mat();
+                CvInvoke.Imdecode(bytes, ImreadModes.ColorBgr, m);
+                return m.IsEmpty ? null : m;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private void SetCurrentImage(Mat image)
+        {
+            _currentImage?.Dispose();
+            _currentImage = image;
+            _previewImage.Source = MaskRcnnPage.MatToImageSource(image);
+            ResetResults();
+        }
+
+        private void ResetResults()
+        {
+            _resultsBody.Children.Clear();
+            _resultsBody.Children.Add(_resultsMessage);
+            _emptyState.IsVisible = true;
+            _resultsMessage.IsVisible = false;
+            _resultsMessage.Text = "";
+            _resultsStatusLabel.Text = "Ready";
+            _resultsStatusLabel.TextColor = MaskRcnnPage.SecondaryText;
+            _resultsCheck.IsVisible = false;
+            _resultsTimeLabel.IsVisible = false;
+            _lastResultPng = null;
+        }
+
+        // ---------- Detection (still image) ----------
+
+        private async void OnDetectClicked(object sender, EventArgs e)
+        {
+            if (_busy || _currentImage == null || _model == null)
+                return;
+
+            _busy = true;
+            _detectButton.IsEnabled = false;
+            SetBusy(true, "Preparing…");
+
+            try
+            {
+                if (!_model.Initialized)
+                {
+                    SetBusy(true, "Downloading model…\n(first time only)");
+                    string selection = CurrentPickerSelection;
+                    await Task.Run(() => _model.Init(OnDownloadProgress, selection));
+                    if (!_model.Initialized)
+                    {
+                        ShowError("Could not download or initialize the model. Check your connection and try again.");
+                        return;
+                    }
+                }
+
+                SetBusy(true, "Analyzing…");
+                Mat input = _currentImage;
+                var sw = Stopwatch.StartNew();
+
+                byte[] png;
+                if (_customProcess != null)
+                {
+                    // Module supplies structured items (e.g. recognized words).
+                    IReadOnlyList<string> items;
+                    (png, items) = await Task.Run(() => _customProcess(_model, input));
+                    sw.Stop();
+                    ShowItemResults(items);
+                }
+                else
+                {
+                    // Generic: annotated image + the model's message string. Most
+                    // models only return timing, so strip it (we show our own
+                    // timestamp) and fall back to a friendly line.
+                    string message;
+                    (png, message) = await Task.Run(() => RunProcess(input));
+                    sw.Stop();
+                    ShowMessageResult(CleanMessage(message));
+                }
+
+                _lastResultPng = png;
+                if (png != null)
+                    _previewImage.Source = MaskRcnnPage.MatBytesToImageSource(png);
+
+                _resultsStatusLabel.TextColor = MaskRcnnPage.PrimaryText;
+                _resultsCheck.IsVisible = true;
+                _resultsTimeLabel.Text = $"Analyzed in {sw.ElapsedMilliseconds} ms";
+                _resultsTimeLabel.IsVisible = true;
+            }
+            catch (Exception ex)
+            {
+                ShowError("Detection failed: " + ex.Message);
+            }
+            finally
+            {
+                _busy = false;
+                _detectButton.IsEnabled = true;
+                SetBusy(false);
+            }
+        }
+
+        // Runs on a background thread: process the image and return the annotated
+        // PNG plus the model's message. Honors the model's RenderMethod.
+        private (byte[] png, string message) RunProcess(Mat input)
+        {
+            if (_renderBuffer == null)
+                _renderBuffer = new Mat();
+            input.CopyTo(_renderBuffer);
+            string msg = _model.ProcessAndRender(input, _renderBuffer);
+            return (MaskRcnnPage.Encode(_renderBuffer), msg);
+        }
+
+        // Show the generic single-message result (annotated image + one line).
+        private void ShowMessageResult(string detail)
+        {
+            _resultsBody.Children.Clear();
+            _resultsBody.Children.Add(_resultsMessage);
+            _resultsMessage.IsVisible = true;
+            _resultsMessage.Text = detail ?? "Results are highlighted on the image above.";
+            _emptyState.IsVisible = false;
+            _resultsStatusLabel.Text = "Complete";
+        }
+
+        // Show a list of textual result items (e.g. recognized words) as rows.
+        private void ShowItemResults(IReadOnlyList<string> items)
+        {
+            _resultsBody.Children.Clear();
+            _resultsMessage.IsVisible = false;
+            _emptyState.IsVisible = false;
+
+            if (items == null || items.Count == 0)
+            {
+                _resultsBody.Children.Add(_resultsMessage);
+                _resultsMessage.IsVisible = true;
+                _resultsMessage.Text = "Nothing recognized in this image.";
+                _resultsStatusLabel.Text = "0 found";
+                return;
+            }
+
+            for (int i = 0; i < items.Count; i++)
+                _resultsBody.Children.Add(BuildTextRow(items[i], i == items.Count - 1));
+            _resultsStatusLabel.Text = items.Count == 1 ? "1 found" : $"{items.Count} found";
+        }
+
+        private static View BuildTextRow(string text, bool isLast)
+        {
+            var icon = MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphCheck, MaskRcnnPage.Accent, 16);
+            var label = new Label { Text = text, FontFamily = MaskRcnnPage.BodyFont, FontSize = 16, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center };
+            var grid = new Grid
+            {
+                Padding = new Thickness(2, 14),
+                ColumnSpacing = 12,
+                ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star) }
+            };
+            grid.Add(icon, 0, 0);
+            grid.Add(label, 1, 0);
+            var stack = new VerticalStackLayout();
+            stack.Children.Add(grid);
+            if (!isLast)
+                stack.Children.Add(new BoxView { HeightRequest = 1, Color = MaskRcnnPage.RowBorder });
+            return stack;
+        }
+
+        // Remove any timing phrase from a model's result message (we show our own
+        // timestamp). Returns null when nothing meaningful is left, so the caller
+        // can substitute a friendly default. Keeps real content (barcode values,
+        // OCR text, "No barcodes found", etc.).
+        private static string CleanMessage(string msg)
+        {
+            if (string.IsNullOrWhiteSpace(msg))
+                return null;
+            // Drop "(in 42 ms)" / "in 42 milliseconds" style phrases.
+            string s = System.Text.RegularExpressions.Regex.Replace(
+                msg, @"\(?\s*in\s+\d+\s*(ms|milliseconds)\s*\)?",
+                "", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            s = s.Trim().Trim('.', ' ', '(', ')').Trim();
+            // "Detected" (with the timing stripped) carries no extra information.
+            if (s.Length == 0 || s.Equals("Detected", StringComparison.OrdinalIgnoreCase))
+                return null;
+            return s;
+        }
+
+        private async void OnLiveDetection(object sender, EventArgs e)
+        {
+#if __IOS__ || __MACCATALYST__
+            await Navigation.PushModalAsync(new ModelShowcaseLivePage(_title, _modelFactory, CurrentPickerSelection));
+#else
+            await Navigation.PushAsync(new Emgu.CV.Platform.Maui.UI.ProcessAndRenderPage(
+                _modelFactory(), _title + " (Live)", null, "Real-time detection from the camera."));
+#endif
+        }
+
+        private void OnDownloadProgress(long? totalBytesToReceive, long bytesReceived, double? progressPercentage)
+        {
+            string msg = totalBytesToReceive != null
+                ? $"Downloading model…\n{bytesReceived / (1024 * 1024)} of {totalBytesToReceive.Value / (1024 * 1024)} MB ({(int)(progressPercentage ?? 0)}%)"
+                : $"Downloading model…\n{bytesReceived / (1024 * 1024)} MB";
+            MainThread.BeginInvokeOnMainThread(() => _loadingLabel.Text = msg);
+        }
+
+        private void ShowError(string message)
+        {
+            _emptyState.IsVisible = true;
+            _resultsMessage.IsVisible = false;
+            ((Label)_emptyState.Children[1]).Text = "Something went wrong";
+            ((Label)_emptyState.Children[2]).Text = message;
+        }
+
+        private void SetBusy(bool busy, string message = "Working…")
+        {
+            _loadingLabel.Text = message;
+            _loadingOverlay.IsVisible = busy;
+            _loadingIndicator.IsRunning = busy;
+        }
+
+        // ---------- Small styled controls ----------
+
+        private Border CircleButton(string glyph, Action onTap)
+        {
+            var cb = new Border
+            {
+                WidthRequest = 44,
+                HeightRequest = 44,
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(22) },
+                VerticalOptions = LayoutOptions.Center,
+                Content = MaskRcnnPage.MakeIcon(glyph, MaskRcnnPage.PrimaryText, 22)
+            };
+            var t = new TapGestureRecognizer();
+            t.Tapped += (s, e) => onTap();
+            cb.GestureRecognizers.Add(t);
+            return cb;
+        }
+
+        private Border PillButton(string glyph, string text, EventHandler onTap)
+        {
+            var pill = new Border
+            {
+                BackgroundColor = MaskRcnnPage.TileBackground,
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(13) },
+                Padding = new Thickness(14, 9),
+                VerticalOptions = LayoutOptions.Center,
+                Content = new HorizontalStackLayout
+                {
+                    Spacing = 7,
+                    Children =
+                    {
+                        MaskRcnnPage.MakeIcon(glyph, MaskRcnnPage.Accent, 18),
+                        new Label { Text = text, FontFamily = MaskRcnnPage.TitleFont, FontSize = 14, TextColor = MaskRcnnPage.Accent, VerticalOptions = LayoutOptions.Center }
+                    }
+                }
+            };
+            var t = new TapGestureRecognizer();
+            t.Tapped += (s, e) => onTap(s, e);
+            pill.GestureRecognizers.Add(t);
+            return pill;
+        }
+    }
+
+#if __IOS__ || __MACCATALYST__
+    /// <summary>
+    /// Full-screen, real-time detection from the camera for any
+    /// <see cref="IProcessAndRenderModel"/>. Mirrors the Mask R-CNN live page but
+    /// drives the generic <see cref="IProcessAndRenderModel.ProcessAndRender"/> per
+    /// frame.
+    /// </summary>
+    internal class ModelShowcaseLivePage : Emgu.Util.AvCaptureSessionPage
+    {
+        private readonly IProcessAndRenderModel _model;
+        private readonly string _pickerSelection;
+        private readonly Image _feed;
+        private readonly Grid _overlay;
+        private readonly Label _loadingLabel;
+        private readonly ActivityIndicator _spinner;
+        private bool _running;
+        private bool _busy;
+        private bool _started;
+        private Mat _frame;
+        private Mat _renderMat;
+
+        public ModelShowcaseLivePage(string title, Func<IProcessAndRenderModel> modelFactory, string pickerSelection)
+        {
+            _model = modelFactory();
+            _pickerSelection = pickerSelection;
+
+            BackgroundColor = MaskRcnnPage.PageBackground;
+            On<Microsoft.Maui.Controls.PlatformConfiguration.iOS>().SetUseSafeArea(true);
+            AllowAvCaptureSession = true;
+            outputRecorder.BufferReceived += OnCameraFrame;
+
+            _feed = new Image { Aspect = Aspect.AspectFill, HorizontalOptions = LayoutOptions.Fill, VerticalOptions = LayoutOptions.Fill };
+
+            var exitRow = new HorizontalStackLayout
+            {
+                Spacing = 2,
+                VerticalOptions = LayoutOptions.Center,
+                HorizontalOptions = LayoutOptions.Start,
+                Children =
+                {
+                    MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphChevronLeft, MaskRcnnPage.Accent, 24),
+                    new Label { Text = "Exit", FontFamily = MaskRcnnPage.TitleFont, FontSize = 17, TextColor = MaskRcnnPage.Accent, VerticalOptions = LayoutOptions.Center }
+                }
+            };
+            var exitTap = new TapGestureRecognizer();
+            exitTap.Tapped += async (s, e) =>
+            {
+                _running = false;
+                await Navigation.PopModalAsync();
+            };
+            exitRow.GestureRecognizers.Add(exitTap);
+
+            var titleLabel = new Label { Text = title, FontFamily = MaskRcnnPage.TitleFont, FontSize = 18, TextColor = MaskRcnnPage.PrimaryText, HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
+
+            var topBar = new Grid
+            {
+                Padding = new Thickness(16, 8, 16, 10),
+                ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) }
+            };
+            topBar.Add(titleLabel, 0, 0);
+            Grid.SetColumnSpan(titleLabel, 3);
+            topBar.Add(exitRow, 0, 0);
+
+            var dot = new Border { WidthRequest = 10, HeightRequest = 10, BackgroundColor = Color.FromArgb("#2BE07A"), Stroke = Colors.Transparent, StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(5) }, VerticalOptions = LayoutOptions.Center };
+            var scanningTitle = new Label { Text = "Scanning…", FontFamily = MaskRcnnPage.TitleFont, FontSize = 15, TextColor = Colors.White };
+            var scanningSub = new Label { Text = "Point your camera at the subject", FontFamily = MaskRcnnPage.BodyFont, FontSize = 13, TextColor = Color.FromArgb("#D6D6DE"), HorizontalOptions = LayoutOptions.Center };
+            var pill = new Border
+            {
+                BackgroundColor = Color.FromArgb("#E01A1C2E"),
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(18) },
+                Padding = new Thickness(22, 12),
+                Margin = new Thickness(0, 0, 0, 20),
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.End,
+                Content = new VerticalStackLayout
+                {
+                    Spacing = 2,
+                    Children =
+                    {
+                        new HorizontalStackLayout { Spacing = 8, HorizontalOptions = LayoutOptions.Center, Children = { dot, scanningTitle } },
+                        scanningSub
+                    }
+                }
+            };
+
+            var feedCard = new Border
+            {
+                BackgroundColor = Colors.Black,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(24) },
+                Margin = new Thickness(16, 4, 16, 20),
+                Content = new Grid { Children = { _feed, pill } }
+            };
+
+            _spinner = new ActivityIndicator { IsRunning = false, Color = MaskRcnnPage.Accent, WidthRequest = 44, HeightRequest = 44, HorizontalOptions = LayoutOptions.Center };
+            _loadingLabel = new Label { Text = "Starting camera…", FontFamily = MaskRcnnPage.BodyFont, FontSize = 15, TextColor = MaskRcnnPage.PrimaryText, HorizontalOptions = LayoutOptions.Center, HorizontalTextAlignment = TextAlignment.Center };
+            var loadingBox = new VerticalStackLayout { Spacing = 14, VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center, Children = { _spinner, _loadingLabel } };
+            _overlay = new Grid { BackgroundColor = Color.FromArgb("#F5EEF1F8"), Children = { loadingBox } };
+
+            var root = new Grid { RowDefinitions = { new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Star) } };
+            root.Add(topBar, 0, 0);
+            root.Add(feedCard, 0, 1);
+
+            Content = new Grid { Children = { root, _overlay } };
+        }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            if (_started)
+                return;
+            _started = true;
+
+            SetOverlay(true, "Downloading model…\n(first time only)");
+            await Task.Run(() => _model.Init(OnDownloadProgress, _pickerSelection));
+            if (!_model.Initialized)
+            {
+                SetOverlay(true, "Could not load the model.\nCheck your connection and exit.");
+                return;
+            }
+
+            SetOverlay(false, null);
+            _running = true;
+            CheckVideoPermissionAndStart();
+        }
+
+        protected override void OnDisappearing()
+        {
+            base.OnDisappearing();
+            _running = false;
+            try { if (session != null) StopCaptureSession(); } catch { }
+
+            Mat frame = _frame;
+            Mat render = _renderMat;
+            _frame = null;
+            _renderMat = null;
+            Task.Run(async () =>
+            {
+                for (int i = 0; i < 40 && _busy; i++)
+                    await Task.Delay(100);
+                try { frame?.Dispose(); } catch { }
+                try { render?.Dispose(); } catch { }
+                try { _model.Dispose(); } catch { }
+            });
+        }
+
+        private void OnCameraFrame(object sender, Emgu.Util.OutputRecorder.BufferReceivedEventArgs e)
+        {
+            if (!_running || _busy)
+                return;
+            _busy = true;
+            try
+            {
+                if (_frame == null)
+                    _frame = new Mat();
+
+                using (CoreVideo.CVPixelBuffer pixelBuffer = e.Buffer.GetImageBuffer() as CoreVideo.CVPixelBuffer)
+                {
+                    pixelBuffer.Lock(CoreVideo.CVPixelBufferLock.ReadOnly);
+                    using (CoreImage.CIImage ciImage = new CoreImage.CIImage(pixelBuffer))
+                        ciImage.ToArray(_frame, ImreadModes.ColorBgr);
+                    pixelBuffer.Unlock(CoreVideo.CVPixelBufferLock.ReadOnly);
+                }
+
+                if (_frame.IsEmpty)
+                    return;
+
+                CvInvoke.Rotate(_frame, _frame, RotateFlags.Rotate90Clockwise);
+
+                if (_renderMat == null)
+                    _renderMat = new Mat();
+                _frame.CopyTo(_renderMat);
+                _model.ProcessAndRender(_frame, _renderMat);
+                byte[] png = MaskRcnnPage.Encode(_renderMat);
+                MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    if (_running)
+                        _feed.Source = MaskRcnnPage.MatBytesToImageSource(png);
+                });
+            }
+            catch
+            {
+                // Skip a bad frame rather than crashing the live feed.
+            }
+            finally
+            {
+                _busy = false;
+            }
+        }
+
+        private void OnDownloadProgress(long? totalBytesToReceive, long bytesReceived, double? progressPercentage)
+        {
+            string msg = totalBytesToReceive != null
+                ? $"Downloading model…\n{bytesReceived / (1024 * 1024)} of {totalBytesToReceive.Value / (1024 * 1024)} MB ({(int)(progressPercentage ?? 0)}%)"
+                : $"Downloading model…\n{bytesReceived / (1024 * 1024)} MB";
+            MainThread.BeginInvokeOnMainThread(() => _loadingLabel.Text = msg);
+        }
+
+        private void SetOverlay(bool visible, string message)
+        {
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                _overlay.IsVisible = visible;
+                _spinner.IsRunning = visible;
+                if (message != null)
+                    _loadingLabel.Text = message;
+            });
+        }
+
+        public override void SetMessage(String message, int heightRequest = 60)
+        {
+            MainThread.BeginInvokeOnMainThread(() => _loadingLabel.Text = message);
+        }
+    }
+#endif
+}

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/ShapeDetectionPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/ShapeDetectionPage.cs
@@ -273,7 +273,11 @@ namespace MauiDemoApp
             {
                 Spacing = 18,
                 Padding = new Thickness(20, 16, 20, 28),
-                Children = { header, sampleCard, _detectButton, resultsCard, pipelineCard }
+                Children =
+                {
+                    header, sampleCard, _detectButton, resultsCard, pipelineCard,
+                    ModelShowcasePage.BuildAboutCard("Finds geometric shapes — triangles, rectangles, circles — in an image using classic contour analysis (no AI model).")
+                }
             };
 
             // ---------- Loading overlay (spinner shown while busy) ----------


### PR DESCRIPTION
## What

Adds a single reusable **`ModelShowcasePage`** and applies it to every detection module in the MAUI demo, so they all share the bespoke experience previously only in the Mask R-CNN / Shape Detection pages — curated sample photos, a photo/camera Change-Photo sheet, a styled results card, and (on iOS) a full-screen live camera — without duplicating ~900 lines per module.

## How it works

The page is driven by the common `IProcessAndRenderModel` contract, so one page handles any model. Each module supplies a small config: title, subtitle, icon, a model factory, sample photos, and (optionally) a version picker. Two hooks keep it flexible:
- **Results cleanup** — strips duplicated timing from the model's message; falls back to "Results are highlighted on the image above" when a model only returns timing.
- **`customProcess`** (optional, per module) — lets a module list structured text in the Results card instead of the generic message.

## Modules converted (from the plain `ProcessAndRenderPage`)

| Module | Notes |
|---|---|
| Scene Text | `customProcess` lists the recognized words |
| PaddleOCR | `customProcess` lists the recognized text (PP-OCRv4) |
| YOLO | version picker |
| Super Resolution | version picker, still-image only |
| Face Detection | detector picker (Yunet / Cascade / FaceLandmark) |
| Tesseract OCR | no camera |
| Video Surveillance | camera-only |
| Pedestrian | — |
| Barcode & QRCode | — |

**Left unchanged:** Shape Detection and Mask R-CNN keep their own bespoke pages (they render structured per-object results the generic contract doesn't expose). The Qwen Chat and SmolVLM2 pages are chat UIs, not detection, so they are out of scope.

## Notes / scope
- Demo-UI only — **no library, model, or native code changed** (2 files, both under `Emgu.CV.Example/MAUI/MauiDemoApp/`).
- Built and run on a physical iPhone (iOS 26.5): sample loads, Change Photo, detect, pickers, and Scene Text / PaddleOCR text lists all verified.