### PR TITLE
MAUI demo: bespoke pages for the Image & 3D modules

### DIFF
--- a/Emgu.CV.Example/MAUI/MauiDemoApp/DrawMatches.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/DrawMatches.cs
@@ -92,6 +92,15 @@ namespace FeatureMatchingExample
         /// <returns>The model image and observed image, the matched features and homography projection.</returns>
         public static Mat Draw(Mat modelImage, Mat observedImage, Feature2D featureDetectorExtractor, out long matchTime)
         {
+            return Draw(modelImage, observedImage, featureDetectorExtractor, out matchTime, out _, out _);
+        }
+
+        /// <summary>
+        /// Same as <see cref="Draw(Mat, Mat, Feature2D, out long)"/> but also reports the number of
+        /// inlier matches and whether the object was located (a homography was found).
+        /// </summary>
+        public static Mat Draw(Mat modelImage, Mat observedImage, Feature2D featureDetectorExtractor, out long matchTime, out int matchCount, out bool objectLocated)
+        {
             Mat homography;
             VectorOfKeyPoint modelKeyPoints;
             VectorOfKeyPoint observedKeyPoints;
@@ -100,6 +109,9 @@ namespace FeatureMatchingExample
                 Mat mask;
                 FindMatch(modelImage, observedImage, featureDetectorExtractor, out matchTime, out modelKeyPoints, out observedKeyPoints, matches,
                    out mask, out homography);
+
+                matchCount = mask == null ? 0 : CvInvoke.CountNonZero(mask);
+                objectLocated = homography != null;
 
                 //Draw the matched keypoints
                 Mat result = new Mat();

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/FeatureMatchingPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/FeatureMatchingPage.cs
@@ -1,100 +1,282 @@
-﻿//----------------------------------------------------------------------------
-//  Copyright (C) 2004-2026 by EMGU Corporation. All rights reserved.       
+//----------------------------------------------------------------------------
+//  Copyright (C) 2004-2026 by EMGU Corporation. All rights reserved.
 //----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.IO;
-using System.Drawing;
 using System.Threading.Tasks;
-#if __ANDROID__
-using Android.App;
-using Android.Content;
-using Android.Runtime;
-using Android.Views;
-using Android.Widget;
-using Android.OS;
-using Android.Graphics;
-using Android.Preferences;
-#endif
 
 using Emgu.CV;
 using Emgu.CV.CvEnum;
 using Emgu.CV.Features;
 using Emgu.CV.XFeatures2D;
-using Emgu.CV.Platform.Maui.UI;
-using Emgu.CV.Structure;
-using Emgu.Util;
+
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Media;
+using Microsoft.Maui.Storage;
+
 using FeatureMatchingExample;
 
 namespace MauiDemoApp
 {
-    public class FeatureMatchingPage : ButtonTextImagePage
+    public class FeatureMatchingPage : SimpleDemoPage
     {
-        public FeatureMatchingPage()
-           : base()
+        private static readonly Color Green = Color.FromArgb("#2BA84A");
+        // Built-in Emgu sample images (file, friendly name, glyph) for either slot.
+        private static readonly (string file, string name, string glyph)[] Samples =
         {
-            this.Title = "Feature Matching";
-            var button = this.GetButton();
-            button.Text = "Perform Feature Matching";
-            button.Clicked += OnButtonClicked;
+            ("box.png", "Box (object)", MaskRcnnPage.GlyphImage),
+            ("box_in_scene.png", "Box on a desk", MaskRcnnPage.GlyphImage),
+            ("lena.jpg", "Portrait", MaskRcnnPage.GlyphImage),
+            ("dog416.png", "Dog & bike", MaskRcnnPage.GlyphDog),
+            ("pedestrian.png", "Street scene", MaskRcnnPage.GlyphWalk),
+        };
 
-            var p = this.Picker;
-            p.Title = "Feature2D type";
-            p.IsVisible = true;
-            p.Items.Add("KAZE");
-            p.Items.Add("SIFT");
+        private readonly Image _image = new Image { Aspect = Aspect.AspectFit, HeightRequest = 220, HorizontalOptions = LayoutOptions.Fill };
+        private readonly Label _matchCount = new Label { Text = "—", FontFamily = MaskRcnnPage.TitleFont, FontSize = 22, TextColor = MaskRcnnPage.PrimaryText };
+        private readonly Label _located = new Label { Text = "—", FontFamily = MaskRcnnPage.TitleFont, FontSize = 22, TextColor = MaskRcnnPage.SecondaryText };
+
+        private readonly Image _modelThumb = new Image { WidthRequest = 46, HeightRequest = 46, Aspect = Aspect.AspectFill };
+        private readonly Image _sceneThumb = new Image { WidthRequest = 46, HeightRequest = 46, Aspect = Aspect.AspectFill };
+        private readonly Label _modelName = new Label { Text = "Box (object)", FontFamily = MaskRcnnPage.BodyFont, FontSize = 14, TextColor = MaskRcnnPage.SecondaryText, VerticalOptions = LayoutOptions.Center };
+        private readonly Label _sceneName = new Label { Text = "Box on a desk", FontFamily = MaskRcnnPage.BodyFont, FontSize = 14, TextColor = MaskRcnnPage.SecondaryText, VerticalOptions = LayoutOptions.Center };
+
+        private Mat _modelMat;
+        private Mat _sceneMat;
+        private int _feature;   // 0 = KAZE, 1 = SIFT
+        private bool _busy;
+        private bool _ran;
+
+        public FeatureMatchingPage(string glyph)
+            : base("Feature Matching", "Find an object in a scene using features", glyph)
+        {
+            var matchesStat = new VerticalStackLayout { Spacing = 2, Children = { new Label { Text = "Matches Found", FontFamily = MaskRcnnPage.BodyFont, FontSize = 13, TextColor = MaskRcnnPage.SecondaryText }, _matchCount } };
+            var locatedStat = new VerticalStackLayout { Spacing = 2, Children = { new Label { Text = "Object Located", FontFamily = MaskRcnnPage.BodyFont, FontSize = 13, TextColor = MaskRcnnPage.SecondaryText }, _located } };
+            var statInner = new Grid { ColumnSpacing = 16, ColumnDefinitions = { new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star) } };
+            statInner.Add(matchesStat, 0, 0);
+            statInner.Add(new BoxView { WidthRequest = 1, Color = MaskRcnnPage.RowBorder }, 1, 0);
+            statInner.Add(locatedStat, 2, 0);
+            var statCard = new Border
+            {
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(14) },
+                Padding = new Thickness(16, 12),
+                Content = statInner
+            };
+
+            var detectorRow = new Grid { ColumnSpacing = 14, ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star) } };
+            detectorRow.Add(new Label { Text = "Detector", FontFamily = MaskRcnnPage.TitleFont, FontSize = 15, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center }, 0, 0);
+            detectorRow.Add(SegmentedToggle(new[] { "KAZE", "SIFT" }, 0, i => _feature = i), 1, 0);
+
+            AddCard(Card(new VerticalStackLayout
+            {
+                Spacing = 14,
+                Children =
+                {
+                    SectionHeader("Match Result", PillButton(MaskRcnnPage.GlyphImage, "Change Images", ChangeImages)),
+                    ImageFrame(_image),
+                    statCard,
+                    detectorRow,
+                    PrimaryButton("Match", MaskRcnnPage.GlyphPlay, (s, e) => Match())
+                }
+            }));
+
+            // ---- Images card: pick model + scene from samples or the photo library ----
+            AddCard(Card(new VerticalStackLayout
+            {
+                Spacing = 4,
+                Children =
+                {
+                    SectionHeader("Images"),
+                    ChooserRow("Model Image", _modelThumb, _modelName, () => PickImage(true)),
+                    new BoxView { HeightRequest = 1, Color = MaskRcnnPage.RowBorder, Margin = new Thickness(0, 4) },
+                    ChooserRow("Scene Image", _sceneThumb, _sceneName, () => PickImage(false))
+                }
+            }));
+
+            AddAbout("Finds a known object inside a cluttered scene: it detects keypoints (KAZE or SIFT), matches them between the two images, and projects the object's outline where it is found — the basis of panorama stitching, object tracking, and AR.");
         }
 
-        private String GetSelectedFeatrure2D()
+        protected override async void OnAppearing()
         {
-            if (this.Picker.SelectedItem == null)
+            base.OnAppearing();
+            if (_ran)
+                return;
+            _ran = true;
+            _modelMat = await LoadPackageImage("box.png");
+            _sceneMat = await LoadPackageImage("box_in_scene.png");
+            if (_modelMat != null) _modelThumb.Source = ToImageSource(_modelMat);
+            if (_sceneMat != null) _sceneThumb.Source = ToImageSource(_sceneMat);
+            Match();
+        }
+
+        protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+        {
+            base.OnNavigatedFrom(args);
+            if (!Navigation.NavigationStack.Contains(this) && !Navigation.ModalStack.Contains(this))
             {
-                return "KAZE"; // default 
+                _modelMat?.Dispose(); _modelMat = null;
+                _sceneMat?.Dispose(); _sceneMat = null;
+            }
+        }
+
+        // A tappable "thumbnail + name + chevron" row.
+        private View ChooserRow(string title, Image thumb, Label nameLabel, Action onTap)
+        {
+            var thumbFrame = new Border
+            {
+                WidthRequest = 46,
+                HeightRequest = 46,
+                BackgroundColor = MaskRcnnPage.ImageBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(10) },
+                Content = thumb
+            };
+            var texts = new VerticalStackLayout { Spacing = 1, VerticalOptions = LayoutOptions.Center, Children = { new Label { Text = title, FontFamily = MaskRcnnPage.TitleFont, FontSize = 16, TextColor = MaskRcnnPage.PrimaryText }, nameLabel } };
+            var grid = new Grid { Padding = new Thickness(2, 10), ColumnSpacing = 14, ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            grid.Add(thumbFrame, 0, 0);
+            grid.Add(texts, 1, 0);
+            grid.Add(MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphChevronRight, MaskRcnnPage.SecondaryText, 22), 2, 0);
+            var tap = new TapGestureRecognizer();
+            tap.Tapped += (s, e) => onTap();
+            grid.GestureRecognizers.Add(tap);
+            return grid;
+        }
+
+        // The "Change Images" pill: pick which slot, then the image.
+        private async void ChangeImages()
+        {
+            var slots = new System.Collections.Generic.List<(string glyph, string label, string value)>
+            {
+                (null, "IMAGE TO CHANGE", null),
+                (MaskRcnnPage.GlyphImage, "Model Image", "model"),
+                (MaskRcnnPage.GlyphImage, "Scene Image", "scene"),
+            };
+            string slot = await ShowChooser("Change Image", slots);
+            if (slot == "model") PickImage(true);
+            else if (slot == "scene") PickImage(false);
+        }
+
+        private async void PickImage(bool isModel)
+        {
+            var options = new System.Collections.Generic.List<(string glyph, string label, string value)>();
+            options.Add((null, "SAMPLE IMAGES", null));
+            foreach (var s in Samples)
+                options.Add((s.glyph, s.name, "sample:" + s.file));
+            options.Add((null, "YOUR PHOTOS", null));
+            options.Add((MaskRcnnPage.GlyphCamera, "Photo Library", "library"));
+
+            string choice = await ShowChooser(isModel ? "Model Image" : "Scene Image", options);
+            if (string.IsNullOrEmpty(choice))
+                return;
+
+            Mat m;
+            string name;
+            if (choice == "library")
+            {
+                FileResult file = await MediaPicker.Default.PickPhotoAsync();
+                if (file == null)
+                    return;
+                SetBusy(true, "Loading photo…");
+                m = await LoadFileImage(file);
+                SetBusy(false);
+                name = "Library photo";
             }
             else
             {
-                return this.Picker.SelectedItem.ToString();
+                string file = choice.Substring("sample:".Length);
+                m = await LoadPackageImage(file);
+                name = file;
+                foreach (var s in Samples)
+                    if (s.file == file) { name = s.name; break; }
+            }
+            if (m == null)
+            {
+                await DisplayAlert("Feature Matching", "That image could not be loaded.", "OK");
+                return;
+            }
+
+            if (isModel)
+            {
+                _modelMat?.Dispose(); _modelMat = m; _modelName.Text = name; _modelThumb.Source = ToImageSource(m);
+            }
+            else
+            {
+                _sceneMat?.Dispose(); _sceneMat = m; _sceneName.Text = name; _sceneThumb.Source = ToImageSource(m);
+            }
+            Match();
+        }
+
+        private async void Match()
+        {
+            if (_busy || _modelMat == null || _sceneMat == null)
+                return;
+            _busy = true;
+            SetBusy(true, "Matching…");
+            try
+            {
+                Mat model = _modelMat, scene = _sceneMat;
+                int feature = _feature;
+                var result = await Task.Run(() =>
+                {
+                    Feature2D fx = feature == 1 ? (Feature2D)new SIFT() : new KAZE();
+                    Mat r = DrawMatches.Draw(model, scene, fx, out long time, out int count, out bool located);
+                    fx.Dispose();
+                    return (image: r, count, located);
+                });
+
+                _image.Source = ToImageSource(result.image);
+                result.image.Dispose();
+
+                _matchCount.Text = result.count.ToString();
+                _matchCount.TextColor = MaskRcnnPage.PrimaryText;
+                _located.Text = result.located ? "Yes" : "No";
+                _located.TextColor = result.located ? Green : MaskRcnnPage.SecondaryText;
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Feature Matching", ex.Message, "OK");
+            }
+            finally
+            {
+                _busy = false;
+                SetBusy(false);
             }
         }
 
-        private async void OnButtonClicked(Object sender, EventArgs args)
+        private static async Task<Mat> LoadPackageImage(string name)
         {
-            Mat[] images = await LoadImages(new String[] { "box.png", "box_in_scene.png" }, new string[] { "Pick a model image from", "Pick a observed image from" });
-            if (images == null || images[0] == null || images[1] == null)
-                return;
-            SetMessage("Please wait...");
-            SetImage(null);
-            Task<Tuple<Mat, long>> t = new Task<Tuple<Mat, long>>(
-                () =>
-                {
-                    long time;
-                    Emgu.CV.Features.Feature2D featureDetectorExtractor;
-                    String pickedFeature2D = GetSelectedFeatrure2D();
+            try
+            {
+                using Stream s = await FileSystem.OpenAppPackageFileAsync(name);
+                using MemoryStream ms = new MemoryStream();
+                await s.CopyToAsync(ms);
+                return Decode(ms.ToArray());
+            }
+            catch { return null; }
+        }
 
-                    if (pickedFeature2D.Equals("SIFT"))
-                    {
-                        featureDetectorExtractor = new SIFT();
-                    }
-                    else
-                    {
-                        featureDetectorExtractor = new KAZE();
-                    }
+        private static async Task<Mat> LoadFileImage(FileResult file)
+        {
+            try
+            {
+                using Stream s = await file.OpenReadAsync();
+                using MemoryStream ms = new MemoryStream();
+                await s.CopyToAsync(ms);
+                return Decode(ms.ToArray());
+            }
+            catch { return null; }
+        }
 
-                    Mat matchResult = DrawMatches.Draw(images[0], images[1], featureDetectorExtractor, out time);
-                    featureDetectorExtractor.Dispose();
-                    return new Tuple<Mat, long>(matchResult, time);
-                });
-            t.Start();
-
-            var result = await t;
-            foreach (var img in images)
-                img.Dispose();
-
-            SetImage(t.Result.Item1);
-            String computeDevice = CvInvoke.UseOpenCL ? "OpenCL: " + Emgu.CV.Ocl.Device.Default.Name : "CPU";
-            SetMessage(String.Format("Detected with {1} using {2} in {0} milliseconds.", t.Result.Item2, computeDevice, GetSelectedFeatrure2D()));
+        private static Mat Decode(byte[] bytes)
+        {
+            Mat m = new Mat();
+            CvInvoke.Imdecode(bytes, ImreadModes.ColorBgr, m);
+            if (m.IsEmpty) { m.Dispose(); return null; }
+            return m;
         }
     }
 }

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/HelloWorldPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/HelloWorldPage.cs
@@ -1,42 +1,118 @@
-﻿//----------------------------------------------------------------------------
-//  Copyright (C) 2004-2026 by EMGU Corporation. All rights reserved.       
+//----------------------------------------------------------------------------
+//  Copyright (C) 2004-2026 by EMGU Corporation. All rights reserved.
 //----------------------------------------------------------------------------
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+
 using Emgu.CV;
-using System.Drawing;
-using Emgu.CV.Structure;
 using Emgu.CV.CvEnum;
-using Emgu.CV.Platform.Maui.UI;
+using Emgu.CV.Structure;
+
+using DrawPoint = System.Drawing.Point;
 
 namespace MauiDemoApp
 {
-    public class HelloWorldPage : ButtonTextImagePage
+    public class HelloWorldPage : SimpleDemoPage
     {
-        public HelloWorldPage()
-           : base()
+        private static readonly Color Green = Color.FromArgb("#2BA84A");
+
+        private readonly Image _img = new Image { Aspect = Aspect.AspectFit, HeightRequest = 240 };
+        private readonly Random _rng = new Random();
+
+        public HelloWorldPage(string glyph)
+            : base("Hello World", "Library smoke test", glyph)
         {
-            this.Title = "Hello World";
-            var button = this.GetButton();
-            if (button != null)
-                button.Opacity = 0;
-            Mat img = new Mat(200, 400, DepthType.Cv8U, 3); //Create a 3 channel image of 400x200
-            img.SetTo(new Bgr(255, 0, 0).MCvScalar); // set it to Blue color
+            Redraw();
 
-            //Draw "Hello, world." on the image using the specific font
-            CvInvoke.PutText(
-               img,
-               "Hello, world",
-               new System.Drawing.Point(10, 80),
-               HersheyFonts.Complex,
-               1.0,
-               new Bgr(0, 255, 0).MCvScalar);
+            AddCard(Card(new VerticalStackLayout
+            {
+                Spacing = 14,
+                Children =
+                {
+                    SectionHeader("Output Image", PillButton(MaskRcnnPage.GlyphPlay, "Draw Again", Redraw)),
+                    ImageFrame(_img),
+                    Caption("Tap “Draw Again” to re-run the draw with random colors.")
+                }
+            }));
 
-            SetImage(img);
-            SetMessage("Hello, world");
+            AddCard(BuildSystemCheck());
+
+            AddAbout("Creates a blue image and writes “Hello, world” in green — the classic smoke test that the whole OpenCV pipeline (create → draw → display) works end to end.");
         }
 
+        // ---- Draw "Hello, world" with a random background/text colour and position ----
+        private void Redraw()
+        {
+            using Mat m = new Mat(200, 400, DepthType.Cv8U, 3);
+            MCvScalar bg = new MCvScalar(_rng.Next(40, 210), _rng.Next(40, 210), _rng.Next(40, 210));
+            m.SetTo(bg);
+            double lum = 0.114 * bg.V0 + 0.587 * bg.V1 + 0.299 * bg.V2;
+            MCvScalar fg = lum > 140 ? new MCvScalar(25, 25, 25) : new MCvScalar(240, 240, 240);
+            int x = 12 + _rng.Next(0, 90);
+            int y = 95 + _rng.Next(0, 55);
+            CvInvoke.PutText(m, "Hello, world", new DrawPoint(x, y), HersheyFonts.Complex, 1.0, fg, 2, LineType.AntiAlias);
+            _img.Source = ToImageSource(m);
+        }
+
+        // ---- "Is it working?" — the smoke test made explicit ----
+        private static View BuildSystemCheck()
+        {
+            var cfg = CvInvoke.ConfigDict;
+            var rows = new VerticalStackLayout { Spacing = 0 };
+            rows.Children.Add(InfoRow("OpenCV version", OpenCvVersion(), true));
+            rows.Children.Add(InfoRow("Worker threads", SafeThreads(), true));
+            rows.Children.Add(CheckRow("DNN module", Have(cfg, "HAVE_OPENCV_DNN"), true));
+            rows.Children.Add(CheckRow("Features (SIFT / KAZE)", Have(cfg, "HAVE_OPENCV_FEATURES"), true));
+            rows.Children.Add(CheckRow("Object detection", Have(cfg, "HAVE_OPENCV_OBJDETECT"), true));
+            rows.Children.Add(CheckRow("Tesseract OCR", Have(cfg, "HAVE_EMGUCV_TESSERACT"), true));
+            rows.Children.Add(CheckRow("Video", Have(cfg, "HAVE_OPENCV_VIDEO"), true));
+            rows.Children.Add(CheckRow("QR / Barcode", Have(cfg, "HAVE_OPENCV_WECHAT_QRCODE"), false));
+
+            return Card(new VerticalStackLayout { Spacing = 12, Children = { SectionHeader("System Check"), rows } });
+        }
+
+        private static bool Have(Dictionary<string, double> cfg, string key) => cfg.TryGetValue(key, out double v) && v != 0;
+
+        private static string SafeThreads()
+        {
+            try { return CvInvoke.NumThreads.ToString(); } catch { return "—"; }
+        }
+
+        private static string OpenCvVersion()
+        {
+            try
+            {
+                var m = System.Text.RegularExpressions.Regex.Match(CvInvoke.BuildInformation ?? "", @"OpenCV\s+(\d+\.\d+\.\d+)");
+                return m.Success ? m.Groups[1].Value : "5.0";
+            }
+            catch { return "—"; }
+        }
+
+        private static View InfoRow(string label, string value, bool divider)
+        {
+            var grid = new Grid { Padding = new Thickness(0, 12), ColumnDefinitions = { new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            grid.Add(new Label { Text = label, FontFamily = MaskRcnnPage.BodyFont, FontSize = 16, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center }, 0, 0);
+            grid.Add(new Label { Text = value, FontFamily = MaskRcnnPage.TitleFont, FontSize = 15, TextColor = MaskRcnnPage.Accent, VerticalOptions = LayoutOptions.Center }, 1, 0);
+            return Wrap(grid, divider);
+        }
+
+        private static View CheckRow(string label, bool ok, bool divider)
+        {
+            var grid = new Grid { Padding = new Thickness(0, 12), ColumnSpacing = 12, ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            grid.Add(MaskRcnnPage.MakeIcon(ok ? MaskRcnnPage.GlyphCheck : MaskRcnnPage.GlyphClose, ok ? Green : MaskRcnnPage.SecondaryText, 18), 0, 0);
+            grid.Add(new Label { Text = label, FontFamily = MaskRcnnPage.BodyFont, FontSize = 16, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center }, 1, 0);
+            grid.Add(new Label { Text = ok ? "Available" : "Not built", FontFamily = MaskRcnnPage.TitleFont, FontSize = 13, TextColor = ok ? Green : MaskRcnnPage.SecondaryText, VerticalOptions = LayoutOptions.Center }, 2, 0);
+            return Wrap(grid, divider);
+        }
+
+        private static View Wrap(View row, bool divider)
+        {
+            var stack = new VerticalStackLayout();
+            stack.Children.Add(row);
+            if (divider)
+                stack.Children.Add(new BoxView { HeightRequest = 1, Color = MaskRcnnPage.RowBorder });
+            return stack;
+        }
     }
 }

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
@@ -121,13 +121,13 @@ namespace MauiDemoApp
 
             helloWorldButton.Clicked += (sender, args) =>
             {
-                this.Navigation.PushAsync(new HelloWorldPage());
+                this.Navigation.PushAsync(new HelloWorldPage(demoGlyph("hello")));
             };
 
             
             planarSubdivisionButton.Clicked += (sender, args) =>
             {
-                this.Navigation.PushAsync(new PlanarSubdivisionPage());
+                this.Navigation.PushAsync(new PlanarSubdivisionPage(demoGlyph("planar")));
             };
 
 
@@ -140,7 +140,7 @@ namespace MauiDemoApp
             
             featureDetectionButton.Clicked += (sender, args) =>
             {
-                this.Navigation.PushAsync(new FeatureMatchingPage());
+                this.Navigation.PushAsync(new FeatureMatchingPage(demoGlyph("feature matching")));
             };
 
             
@@ -489,7 +489,7 @@ namespace MauiDemoApp
 
                 unicodeRenderingButton.Clicked += (sender, args) =>
                 {
-                    this.Navigation.PushAsync(new UnicodeRenderingPage());
+                    this.Navigation.PushAsync(new UnicodeRenderingPage(demoGlyph("unicode")));
                 };
             }
             

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/PlanarSubdivisionPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/PlanarSubdivisionPage.cs
@@ -1,30 +1,87 @@
-﻿//----------------------------------------------------------------------------
-//  Copyright (C) 2004-2026 by EMGU Corporation. All rights reserved.       
+//----------------------------------------------------------------------------
+//  Copyright (C) 2004-2026 by EMGU Corporation. All rights reserved.
 //----------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using Emgu.CV.Platform.Maui.UI;
+
+using Emgu.CV;
+
+using Microsoft.Maui.Controls.Shapes;
+
 using PlanarSubdivisionExample;
 
 namespace MauiDemoApp
 {
-    public class PlanarSubdivisionPage : ButtonTextImagePage
+    public class PlanarSubdivisionPage : SimpleDemoPage
     {
-       public PlanarSubdivisionPage()
-       {
-          this.Title = "Planar Subdivision";
-          var button = this.GetButton();
-          button.Text = "Calculate Planar Subdivision";
-          button.Clicked += (sender, args) =>
-          {
-             int maxValue = 600, pointCount = 30;
+        private const int MaxValue = 600;
 
-              //DisplayImage.SetImage(DrawSubdivision.Draw(maxValue, pointCount));
-              SetImage(DrawSubdivision.Draw(maxValue, pointCount));
-              SetMessage(String.Format( "Generated planar subdivision for {0} points", pointCount));
-          };
-       }
+        private readonly Image _image = new Image { Aspect = Aspect.AspectFit, HeightRequest = 300, HorizontalOptions = LayoutOptions.Fill };
+        private readonly Label _badge = new Label { Text = "30 points", FontFamily = MaskRcnnPage.TitleFont, FontSize = 13, TextColor = MaskRcnnPage.Accent };
+        private readonly Label _sliderValue = new Label { Text = "30 points", FontFamily = MaskRcnnPage.TitleFont, FontSize = 15, TextColor = MaskRcnnPage.Accent, HorizontalOptions = LayoutOptions.End, VerticalOptions = LayoutOptions.Center };
+        private int _pointCount = 30;
+
+        public PlanarSubdivisionPage(string glyph)
+            : base("Planar Subdivision", "Delaunay triangulation & Voronoi diagram", glyph)
+        {
+            var badgeBorder = new Border
+            {
+                BackgroundColor = MaskRcnnPage.TileBackground,
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(11) },
+                Padding = new Thickness(12, 6),
+                VerticalOptions = LayoutOptions.Center,
+                Content = _badge
+            };
+
+            AddCard(Card(new VerticalStackLayout
+            {
+                Spacing = 14,
+                Children =
+                {
+                    SectionHeader("Subdivision", badgeBorder),
+                    ImageFrame(_image),
+                    Caption("Colored Voronoi cells with the Delaunay triangulation overlaid. Each dot is a cell centre.")
+                }
+            }));
+
+            AddCard(PrimaryButton("New Points", MaskRcnnPage.GlyphPlay, (s, e) => Generate()));
+
+            // ---- Point-count slider card ----
+            var slider = new Slider { Minimum = 10, Maximum = 100, Value = 30, MinimumTrackColor = MaskRcnnPage.Accent, ThumbColor = MaskRcnnPage.Accent, HorizontalOptions = LayoutOptions.Fill };
+            slider.ValueChanged += (s, e) =>
+            {
+                _pointCount = (int)Math.Round(e.NewValue);
+                _sliderValue.Text = $"{_pointCount} points";
+            };
+            slider.DragCompleted += (s, e) => Generate();
+
+            var sliderRow = new Grid { ColumnSpacing = 12, ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            sliderRow.Add(new Label { Text = "10", FontFamily = MaskRcnnPage.BodyFont, FontSize = 13, TextColor = MaskRcnnPage.SecondaryText, VerticalOptions = LayoutOptions.Center }, 0, 0);
+            sliderRow.Add(slider, 1, 0);
+            sliderRow.Add(new Label { Text = "100", FontFamily = MaskRcnnPage.BodyFont, FontSize = 13, TextColor = MaskRcnnPage.SecondaryText, VerticalOptions = LayoutOptions.Center }, 2, 0);
+
+            AddCard(Card(new VerticalStackLayout
+            {
+                Spacing = 8,
+                Children =
+                {
+                    SectionHeader("Point Count", _sliderValue),
+                    sliderRow,
+                    Caption("Adjust the number of random points.")
+                }
+            }));
+
+            AddAbout("Scatters random points, then builds and draws the Delaunay triangulation and Voronoi diagram between them — a demo of OpenCV's computational geometry (Subdiv2D).");
+
+            Generate();
+        }
+
+        private void Generate()
+        {
+            using (Mat m = DrawSubdivision.Draw(MaxValue, _pointCount))
+                _image.Source = ToImageSource(m);
+            _badge.Text = $"{_pointCount} points";
+        }
     }
 }

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/SimpleDemoPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/SimpleDemoPage.cs
@@ -1,0 +1,361 @@
+//----------------------------------------------------------------------------
+//  Copyright (C) 2004-2026 by EMGU Corporation. All rights reserved.
+//----------------------------------------------------------------------------
+
+using System;
+using System.IO;
+
+using Emgu.CV;
+
+using Microsoft.Maui.Controls.Shapes;
+
+namespace MauiDemoApp
+{
+    /// <summary>
+    /// Shared, on-theme scaffolding for the "generate / process → show an image"
+    /// demos (Hello World, Planar Subdivision, Feature Matching, Unicode
+    /// Rendering) so they match the detection pages' look. It provides the themed
+    /// header, a scrolling body that subclasses fill with cards, a loading
+    /// overlay, and styled builders (cards, section headers, image frame, primary
+    /// button) plus the same collapsible "About this module" card.
+    /// </summary>
+    public abstract class SimpleDemoPage : ContentPage
+    {
+        private readonly VerticalStackLayout _body;
+        private readonly Grid _loadingOverlay;
+        private readonly Label _loadingLabel;
+        private readonly ActivityIndicator _loadingIndicator;
+
+        // Bottom-sheet chooser (same style as the Mask R-CNN Change Photo sheet).
+        private readonly Grid _sheetOverlay;
+        private readonly BoxView _sheetScrim;
+        private readonly Border _sheetCard;
+        private readonly VerticalStackLayout _sheetList;
+        private System.Threading.Tasks.TaskCompletionSource<string> _sheetTcs;
+        private bool _sheetAnimating;
+
+        protected SimpleDemoPage(string title, string subtitle, string glyph)
+        {
+            Title = title;
+            BackgroundColor = MaskRcnnPage.PageBackground;
+            Shell.SetNavBarIsVisible(this, false);
+
+            var headerTile = new Border
+            {
+                WidthRequest = 64,
+                HeightRequest = 64,
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(18) },
+                VerticalOptions = LayoutOptions.Start,
+                Content = MaskRcnnPage.MakeIcon(glyph, MaskRcnnPage.Accent, 32)
+            };
+            var titleLabel = new Label { Text = title, FontFamily = MaskRcnnPage.TitleFont, FontSize = 30, TextColor = MaskRcnnPage.PrimaryText };
+            var subtitleLabel = new Label { Text = subtitle, FontFamily = MaskRcnnPage.BodyFont, FontSize = 15, TextColor = MaskRcnnPage.SecondaryText, Margin = new Thickness(0, 2, 0, 0) };
+            var titleStack = new VerticalStackLayout { VerticalOptions = LayoutOptions.Center, Children = { titleLabel, subtitleLabel } };
+
+            var backButton = CircleButton(MaskRcnnPage.GlyphChevronLeft, async () => await Navigation.PopAsync());
+            var infoButton = CircleButton(MaskRcnnPage.GlyphInfo, async () => await Navigation.PushAsync(new AboutPage()));
+
+            var topRow = new Grid { ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            topRow.Add(backButton, 0, 0);
+            topRow.Add(infoButton, 2, 0);
+
+            var headerBody = new Grid
+            {
+                ColumnSpacing = 16,
+                Margin = new Thickness(0, 12, 0, 0),
+                ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star) }
+            };
+            headerBody.Add(headerTile, 0, 0);
+            headerBody.Add(titleStack, 1, 0);
+
+            var header = new VerticalStackLayout { Children = { topRow, headerBody } };
+
+            _body = new VerticalStackLayout
+            {
+                Spacing = 18,
+                Padding = new Thickness(20, 16, 20, 28),
+                Children = { header }
+            };
+
+            _loadingIndicator = new ActivityIndicator { IsRunning = false, Color = MaskRcnnPage.Accent, WidthRequest = 44, HeightRequest = 44, HorizontalOptions = LayoutOptions.Center };
+            _loadingLabel = new Label { Text = "Working…", FontFamily = MaskRcnnPage.BodyFont, FontSize = 15, TextColor = MaskRcnnPage.PrimaryText, HorizontalOptions = LayoutOptions.Center, HorizontalTextAlignment = TextAlignment.Center };
+            var loadingCard = new Border
+            {
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                Padding = new Thickness(28, 22),
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(20) },
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.Center,
+                Content = new VerticalStackLayout { Spacing = 14, WidthRequest = 240, Children = { _loadingIndicator, _loadingLabel } }
+            };
+            _loadingOverlay = new Grid { IsVisible = false, BackgroundColor = Color.FromArgb("#B3EEF1F8"), Children = { loadingCard } };
+
+            // Bottom-sheet chooser overlay (hidden until ShowChooser is called).
+            _sheetList = new VerticalStackLayout { Spacing = 0 };
+            _sheetCard = new Border
+            {
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(28, 28, 0, 0) },
+                Padding = new Thickness(20, 8, 20, 60),
+                Margin = new Thickness(0, 0, 0, -40),
+                VerticalOptions = LayoutOptions.End,
+                Content = _sheetList
+            };
+            _sheetScrim = new BoxView { Color = Color.FromArgb("#66000000"), Opacity = 0, Margin = new Thickness(0, -120, 0, -120) };
+            var scrimTap = new TapGestureRecognizer();
+            scrimTap.Tapped += (s, e) => CloseSheet(null);
+            _sheetScrim.GestureRecognizers.Add(scrimTap);
+            _sheetOverlay = new Grid { IsVisible = false, Children = { _sheetScrim, _sheetCard } };
+
+            Content = new Grid { Children = { new Microsoft.Maui.Controls.ScrollView { Content = _body }, _loadingOverlay, _sheetOverlay } };
+        }
+
+        // ---------- Bottom-sheet chooser ----------
+
+        /// <summary>Show a Mask R-CNN-style bottom sheet and return the chosen value (null = cancelled).</summary>
+        protected System.Threading.Tasks.Task<string> ShowChooser(string title, System.Collections.Generic.IList<(string glyph, string label, string value)> options)
+        {
+            _sheetTcs = new System.Threading.Tasks.TaskCompletionSource<string>();
+
+            _sheetList.Children.Clear();
+            _sheetList.Children.Add(new BoxView { WidthRequest = 40, HeightRequest = 5, CornerRadius = 3, Color = Color.FromArgb("#D5D8E0"), HorizontalOptions = LayoutOptions.Center, Margin = new Thickness(0, 10, 0, 6) });
+            _sheetList.Children.Add(new Label { Text = title, FontFamily = MaskRcnnPage.TitleFont, FontSize = 20, TextColor = MaskRcnnPage.PrimaryText, HorizontalOptions = LayoutOptions.Center, Margin = new Thickness(0, 0, 0, 6) });
+            // An option with a null value is rendered as a section heading.
+            for (int i = 0; i < options.Count; i++)
+            {
+                if (options[i].value == null)
+                    _sheetList.Children.Add(SheetSection(options[i].label));
+                else
+                    _sheetList.Children.Add(SheetRow(options[i].glyph, options[i].label, options[i].value, i + 1 < options.Count && options[i + 1].value != null));
+            }
+
+            var cancel = new Border { BackgroundColor = Color.FromArgb("#F2F2F7"), Stroke = Colors.Transparent, StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(14) }, HeightRequest = 52, Margin = new Thickness(0, 14, 0, 0), Content = new Label { Text = "Cancel", FontFamily = MaskRcnnPage.TitleFont, FontSize = 17, TextColor = MaskRcnnPage.Accent, HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center } };
+            var cancelTap = new TapGestureRecognizer();
+            cancelTap.Tapped += (s, e) => CloseSheet(null);
+            cancel.GestureRecognizers.Add(cancelTap);
+            _sheetList.Children.Add(cancel);
+
+            _sheetOverlay.IsVisible = true;
+            _sheetScrim.Opacity = 0;
+            _sheetCard.TranslationY = 700;
+            _ = System.Threading.Tasks.Task.WhenAll(
+                _sheetScrim.FadeTo(1, 220, Easing.CubicOut),
+                _sheetCard.TranslateTo(0, 0, 260, Easing.CubicOut));
+            return _sheetTcs.Task;
+        }
+
+        private static View SheetSection(string text) => new Label
+        {
+            Text = text,
+            FontFamily = MaskRcnnPage.TitleFont,
+            FontSize = 12,
+            TextColor = MaskRcnnPage.SecondaryText,
+            CharacterSpacing = 1.2,
+            Margin = new Thickness(2, 16, 0, 2)
+        };
+
+        /// <summary>A small rounded accent pill button (glyph + text), like the Change Photo pill.</summary>
+        protected View PillButton(string glyph, string text, Action onTap)
+        {
+            var pill = new Border
+            {
+                BackgroundColor = MaskRcnnPage.TileBackground,
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(13) },
+                Padding = new Thickness(14, 9),
+                VerticalOptions = LayoutOptions.Center,
+                Content = new HorizontalStackLayout
+                {
+                    Spacing = 7,
+                    Children =
+                    {
+                        MaskRcnnPage.MakeIcon(glyph, MaskRcnnPage.Accent, 18),
+                        new Label { Text = text, FontFamily = MaskRcnnPage.TitleFont, FontSize = 14, TextColor = MaskRcnnPage.Accent, VerticalOptions = LayoutOptions.Center }
+                    }
+                }
+            };
+            var t = new TapGestureRecognizer();
+            t.Tapped += (s, e) => onTap();
+            pill.GestureRecognizers.Add(t);
+            return pill;
+        }
+
+        private View SheetRow(string glyph, string text, string value, bool divider)
+        {
+            var grid = new Grid { Padding = new Thickness(2, 14), ColumnSpacing = 16, ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star) } };
+            grid.Add(MaskRcnnPage.MakeIcon(glyph, MaskRcnnPage.Accent, 26), 0, 0);
+            grid.Add(new Label { Text = text, FontFamily = MaskRcnnPage.BodyFont, FontSize = 17, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center }, 1, 0);
+            var tap = new TapGestureRecognizer();
+            tap.Tapped += (s, e) => CloseSheet(value);
+            grid.GestureRecognizers.Add(tap);
+
+            var stack = new VerticalStackLayout();
+            stack.Children.Add(grid);
+            if (divider)
+                stack.Children.Add(new BoxView { HeightRequest = 1, Color = MaskRcnnPage.RowBorder, Margin = new Thickness(42, 0, 0, 0) });
+            return stack;
+        }
+
+        private async void CloseSheet(string value)
+        {
+            if (_sheetAnimating)
+                return;
+            _sheetAnimating = true;
+            await System.Threading.Tasks.Task.WhenAll(
+                _sheetScrim.FadeTo(0, 180, Easing.CubicIn),
+                _sheetCard.TranslateTo(0, 700, 220, Easing.CubicIn));
+            _sheetOverlay.IsVisible = false;
+            _sheetAnimating = false;
+            _sheetTcs?.TrySetResult(value);
+        }
+
+        // ---------- Composition API for subclasses ----------
+
+        /// <summary>Append a card/section to the page body (in order).</summary>
+        protected void AddCard(View card) => _body.Children.Add(card);
+
+        /// <summary>Append the collapsible "About this module" card (shared with the detection pages).</summary>
+        protected void AddAbout(string about)
+        {
+            if (!string.IsNullOrWhiteSpace(about))
+                _body.Children.Add(ModelShowcasePage.BuildAboutCard(about));
+        }
+
+        protected void SetBusy(bool busy, string message = "Working…")
+        {
+            _loadingLabel.Text = message;
+            _loadingOverlay.IsVisible = busy;
+            _loadingIndicator.IsRunning = busy;
+        }
+
+        // ---------- Styled builders ----------
+
+        /// <summary>A white rounded content card.</summary>
+        protected static Border Card(View content) => new Border
+        {
+            BackgroundColor = MaskRcnnPage.CardBackground,
+            Stroke = Colors.Transparent,
+            StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(22) },
+            Padding = new Thickness(16),
+            Content = content
+        };
+
+        /// <summary>A card title row with an optional trailing view (badge / stat).</summary>
+        protected static View SectionHeader(string title, View trailing = null)
+        {
+            var label = new Label { Text = title, FontFamily = MaskRcnnPage.TitleFont, FontSize = 19, TextColor = MaskRcnnPage.PrimaryText, VerticalOptions = LayoutOptions.Center };
+            if (trailing == null)
+                return label;
+            var grid = new Grid { ColumnDefinitions = { new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            grid.Add(label, 0, 0);
+            grid.Add(trailing, 1, 0);
+            return grid;
+        }
+
+        /// <summary>The light rounded frame the result image sits in.</summary>
+        protected static Border ImageFrame(Image img) => new Border
+        {
+            BackgroundColor = MaskRcnnPage.ImageBackground,
+            Stroke = MaskRcnnPage.RowBorder,
+            StrokeThickness = 1,
+            Padding = new Thickness(10),
+            StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(16) },
+            Content = img
+        };
+
+        protected static Label Caption(string text) => new Label
+        {
+            Text = text,
+            FontFamily = MaskRcnnPage.BodyFont,
+            FontSize = 14,
+            TextColor = MaskRcnnPage.SecondaryText
+        };
+
+        /// <summary>Full-width accent primary button with a leading glyph.</summary>
+        protected Button PrimaryButton(string text, string glyph, EventHandler onClick)
+        {
+            var button = new Button
+            {
+                Text = text,
+                FontFamily = MaskRcnnPage.TitleFont,
+                FontSize = 17,
+                BackgroundColor = MaskRcnnPage.Accent,
+                TextColor = Colors.White,
+                CornerRadius = 16,
+                HeightRequest = 56,
+                ImageSource = new FontImageSource { FontFamily = MaskRcnnPage.IconFont, Glyph = glyph, Color = Colors.White, Size = 20 },
+                ContentLayout = new Button.ButtonContentLayout(Button.ButtonContentLayout.ImagePosition.Left, 8)
+            };
+            button.Clicked += onClick;
+            return button;
+        }
+
+        protected static ImageSource ToImageSource(Mat m) => MaskRcnnPage.MatToImageSource(m);
+
+        /// <summary>A 2-plus option segmented pill toggle (e.g. KAZE / SIFT). Manages its own selection visuals.</summary>
+        protected static View SegmentedToggle(string[] options, int initial, Action<int> onSelect)
+        {
+            var labels = new Label[options.Length];
+            var cells = new Border[options.Length];
+            var inner = new Grid { ColumnSpacing = 4 };
+            int selected = initial;
+
+            void Refresh()
+            {
+                for (int i = 0; i < options.Length; i++)
+                {
+                    bool on = i == selected;
+                    cells[i].BackgroundColor = on ? MaskRcnnPage.Accent : Colors.Transparent;
+                    labels[i].TextColor = on ? Colors.White : MaskRcnnPage.PrimaryText;
+                }
+            }
+
+            for (int i = 0; i < options.Length; i++)
+            {
+                inner.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Star));
+                labels[i] = new Label { Text = options[i], FontFamily = MaskRcnnPage.TitleFont, FontSize = 15, HorizontalTextAlignment = TextAlignment.Center, VerticalTextAlignment = TextAlignment.Center };
+                cells[i] = new Border { Stroke = Colors.Transparent, StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(11) }, HeightRequest = 40, Content = labels[i] };
+                int idx = i;
+                var tap = new TapGestureRecognizer();
+                tap.Tapped += (s, e) => { selected = idx; Refresh(); onSelect(idx); };
+                cells[i].GestureRecognizers.Add(tap);
+                inner.Add(cells[i], i, 0);
+            }
+            Refresh();
+
+            return new Border
+            {
+                BackgroundColor = MaskRcnnPage.ImageBackground,
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(13) },
+                Padding = new Thickness(3),
+                Content = inner
+            };
+        }
+
+        private Border CircleButton(string glyph, Action onTap)
+        {
+            var cb = new Border
+            {
+                WidthRequest = 44,
+                HeightRequest = 44,
+                BackgroundColor = MaskRcnnPage.CardBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(22) },
+                VerticalOptions = LayoutOptions.Center,
+                Content = MaskRcnnPage.MakeIcon(glyph, MaskRcnnPage.PrimaryText, 22)
+            };
+            var t = new TapGestureRecognizer();
+            t.Tapped += (s, e) => onTap();
+            cb.GestureRecognizers.Add(t);
+            return cb;
+        }
+    }
+}

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/UnicodeRenderingPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/UnicodeRenderingPage.cs
@@ -4,114 +4,161 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using Emgu.CV;
-using System.Drawing;
 using System.Threading.Tasks;
-using Emgu.CV.Structure;
+
+using Emgu.CV;
 using Emgu.CV.CvEnum;
 using Emgu.CV.Freetype;
 using Emgu.CV.Models;
-using Emgu.CV.Platform.Maui.UI;
-using Emgu.Util;
+using Emgu.CV.Structure;
 
-using Size = System.Drawing.Size;
-using Point = System.Drawing.Point;
+using Microsoft.Maui.Controls.Shapes;
+
+using DrawSize = System.Drawing.Size;
+using DrawPoint = System.Drawing.Point;
 
 namespace MauiDemoApp
 {
-    public class UnicodeRenderingPage : ButtonTextImagePage
+    public class UnicodeRenderingPage : SimpleDemoPage
     {
-        private const String _renderWithFontFace = "FontFace";
-        private const String _renderWithFreetype = "FreeType";
+        private const string RenderFontFace = "FontFace";
+        private const string RenderFreetype = "FreeType";
 
-        private static readonly String[] _helloTexts = new String[]
+        private static readonly MCvScalar[] Palette =
         {
-            "Hello",
-            "您好",
-            "こんにちは",
-            "여보세요",
-            "Здравствуйте"
+            new MCvScalar(80, 220, 100), new MCvScalar(70, 220, 230), new MCvScalar(200, 150, 240),
+            new MCvScalar(230, 210, 120), new MCvScalar(230, 130, 200)
         };
+
+        private readonly Image _image = new Image { Aspect = Aspect.AspectFit, HeightRequest = 300, HorizontalOptions = LayoutOptions.Fill };
+        private readonly Editor _editor = new Editor
+        {
+            Text = "Hello\n您好\nこんにちは\n여보세요\nЗдравствуйте",
+            FontSize = 16,
+            HeightRequest = 128,
+            BackgroundColor = Colors.Transparent,
+            TextColor = MaskRcnnPage.PrimaryText
+        };
+        private readonly Label _status = new Label { Text = "Ready", FontFamily = MaskRcnnPage.TitleFont, FontSize = 13, TextColor = MaskRcnnPage.Accent };
+        private readonly bool _haveFreetype = CvInvoke.ConfigDict["HAVE_OPENCV_FREETYPE"] != 0;
 
         private FontFace _fontFace;
         private FreetypeNotoSansCJK _freetype2;
+        private string _renderOption = RenderFontFace;
+        private bool _busy;
+        private bool _drawn;
 
-        public UnicodeRenderingPage()
-            : base()
+        public UnicodeRenderingPage(string glyph)
+            : base("Unicode Rendering", "Draw text in any language on an image", glyph)
         {
-            this.Title = "Unicode Rendering";
-
-            var picker = this.Picker;
-            picker.Title = "Render with";
-            picker.Items.Add(_renderWithFontFace);
-            bool haveFreetype = CvInvoke.ConfigDict["HAVE_OPENCV_FREETYPE"] != 0;
-            if (haveFreetype)
-                picker.Items.Add(_renderWithFreetype);
-            picker.SelectedIndex = 0;
-            //No need to show the picker if FontFace is the only option
-            picker.IsVisible = haveFreetype;
-
-            var button = this.GetButton();
-            button.Text = "Draw Unicode Text";
-            button.Clicked += async (sender, args) =>
+            AddCard(Card(new VerticalStackLayout
             {
-                String renderOption = picker.Items[picker.SelectedIndex];
-
-                Mat img = new Mat(new Size(640, 480), DepthType.Cv8U, 3);
-                img.SetTo(new MCvScalar(0, 0, 0, 0));
-                MCvScalar color = new MCvScalar(255, 255, 0);
-
-                if (renderOption.Equals(_renderWithFreetype))
+                Spacing = 14,
+                Children =
                 {
-                    if (_freetype2 == null)
-                    {
-                        _freetype2 = new FreetypeNotoSansCJK();
-                        try
-                        {
-                            await Task.Run(() => _freetype2.Init(DownloadManager_OnDownloadProgressChanged));
-                        }
-                        catch (Exception ex)
-                        {
-                            SetMessage(String.Format("Failed to initialize FreeType: {0}", ex.Message));
-                            _freetype2 = null;
-                            return;
-                        }
-                    }
-
-                    for (int i = 0; i < _helloTexts.Length; i++)
-                        _freetype2.PutText(img, _helloTexts[i], new Point(100, 50 + i * 50), 36, color, 1,
-                            LineType.EightConnected, false);
-                    SetMessage("\"Hello\" in 5 languages rendered with the freetype module");
+                    SectionHeader("Rendered Image"),
+                    ImageFrame(_image),
+                    Caption("Your text drawn with OpenCV's Unicode text rendering.")
                 }
-                else
-                {
-                    if (_fontFace == null)
-                    {
-                        //The built-in Unicode font ("uni", WenQuanYi Micro Hei) is
-                        //required for the CJK text; fall back to the default embedded
-                        //font if the native library was built without WITH_UNIFONT.
-                        _fontFace = new FontFace();
-                        _fontFace.Set("uni");
-                    }
+            }));
 
-                    for (int i = 0; i < _helloTexts.Length; i++)
-                        CvInvoke.PutText(img, _helloTexts[i], new Point(100, 50 + i * 50), color, _fontFace, 36);
-                    SetMessage(String.Format(
-                        "\"Hello\" in 5 languages rendered with FontFace (\"{0}\")",
-                        _fontFace.Name));
-                }
-
-                SetImage(img);
+            var editorFrame = new Border
+            {
+                BackgroundColor = MaskRcnnPage.ImageBackground,
+                Stroke = MaskRcnnPage.RowBorder,
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(14) },
+                Padding = new Thickness(10, 2),
+                Content = _editor
             };
+
+            var inputChildren = new VerticalStackLayout { Spacing = 14 };
+            inputChildren.Children.Add(new Label { Text = "Your Text", FontFamily = MaskRcnnPage.TitleFont, FontSize = 17, TextColor = MaskRcnnPage.PrimaryText });
+            inputChildren.Children.Add(Caption("Type anything — English, 中文, 日本語, 한국어, Русский — one line each."));
+            inputChildren.Children.Add(editorFrame);
+            if (_haveFreetype)
+                inputChildren.Children.Add(SegmentedToggle(new[] { RenderFontFace, RenderFreetype }, 0, i => { _renderOption = i == 0 ? RenderFontFace : RenderFreetype; DrawText(); }));
+            inputChildren.Children.Add(PrimaryButton("Draw", MaskRcnnPage.GlyphPlay, (s, e) => DrawText()));
+
+            var statusRow = new Grid { ColumnDefinitions = { new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) } };
+            statusRow.Add(new Label { Text = "Renderer: " + (_haveFreetype ? "FontFace / FreeType" : "FontFace"), FontFamily = MaskRcnnPage.BodyFont, FontSize = 13, TextColor = MaskRcnnPage.SecondaryText, VerticalOptions = LayoutOptions.Center }, 0, 0);
+            statusRow.Add(_status, 1, 0);
+            inputChildren.Children.Add(statusRow);
+
+            AddCard(Card(inputChildren));
+
+            AddAbout("Plain OpenCV text only supports ASCII. This renders any Unicode text (CJK, Cyrillic, …) onto an image using the FontFace, and optionally the FreeType, text APIs.");
         }
 
-        private void DownloadManager_OnDownloadProgressChanged(long? totalBytesToReceive, long bytesReceived, double? progressPercentage)
+        protected override void OnAppearing()
         {
-            if (totalBytesToReceive == null)
-                SetMessage(String.Format("{0} bytes downloaded.", bytesReceived));
-            else
-                SetMessage(String.Format("{0} of {1} bytes downloaded ({2}%)", bytesReceived, totalBytesToReceive, progressPercentage));
+            base.OnAppearing();
+            if (_drawn)
+                return;
+            _drawn = true;
+            DrawText();
+        }
+
+        private async void DrawText()
+        {
+            if (_busy)
+                return;
+            _busy = true;
+            try
+            {
+                var lines = new List<string>();
+                foreach (string raw in (_editor.Text ?? string.Empty).Replace("\r", "").Split('\n'))
+                    if (!string.IsNullOrWhiteSpace(raw))
+                        lines.Add(raw.Trim());
+                if (lines.Count == 0)
+                    lines.Add("Hello");
+
+                bool useFreetype = _renderOption == RenderFreetype && _haveFreetype;
+                if (useFreetype && _freetype2 == null)
+                {
+                    SetBusy(true, "Downloading font…\n(first time only)");
+                    _freetype2 = new FreetypeNotoSansCJK();
+                    try { await Task.Run(() => _freetype2.Init(null)); }
+                    catch (Exception ex) { SetBusy(false); _status.Text = "FreeType failed"; _freetype2 = null; useFreetype = false; System.Diagnostics.Debug.WriteLine("FreeType init: " + ex); }
+                    SetBusy(false);
+                }
+
+                int rowH = 84;
+                using Mat img = new Mat(new DrawSize(700, 60 + lines.Count * rowH), DepthType.Cv8U, 3);
+                img.SetTo(new MCvScalar(26, 16, 12));   // dark navy
+
+                for (int i = 0; i < lines.Count; i++)
+                {
+                    MCvScalar color = Palette[i % Palette.Length];
+                    int y = 66 + i * rowH;
+                    if (useFreetype)
+                        _freetype2.PutText(img, lines[i], new DrawPoint(40, y), 44, color, 1, LineType.EightConnected, false);
+                    else
+                        CvInvoke.PutText(img, lines[i], new DrawPoint(40, y), color, GetFontFace(), 44);
+                }
+
+                _image.Source = ToImageSource(img);
+                _status.Text = useFreetype ? "FreeType" : "FontFace";
+            }
+            catch (Exception ex)
+            {
+                _status.Text = "Error";
+                await DisplayAlert("Unicode Rendering", ex.Message, "OK");
+            }
+            finally
+            {
+                _busy = false;
+            }
+        }
+
+        private FontFace GetFontFace()
+        {
+            if (_fontFace == null)
+            {
+                _fontFace = new FontFace();
+                _fontFace.Set("uni");   // built-in Unicode font (CJK-capable)
+            }
+            return _fontFace;
         }
     }
 }


### PR DESCRIPTION
## What

Gives the **Image & 3D** demos (Hello World, Planar Subdivision, Feature Matching, Unicode Rendering) the same bespoke, on-theme look as the detection pages (PR #1042), via a shared `SimpleDemoPage` base — no more plain `ButtonTextImagePage` screens.

## Commits (reviewable step by step)
1. **`SimpleDemoPage` base** — themed header, styled cards, image frame, loading overlay, bottom-sheet chooser, segmented toggle, primary/pill buttons, and the shared collapsible About card.
2. **`DrawMatches` overload** — reports the inlier match count and whether the object was located (homography found); the existing signature is kept and forwards to it.
3. **The four pages rebuilt** on `SimpleDemoPage` + `MainPage` passes each its glyph.

## Pages
- **Hello World** — draws "Hello, world" (random colours on *Draw Again*) plus a **System Check** panel (OpenCV version, worker threads, and which modules are available) — the smoke test made explicit.
- **Planar Subdivision** — Delaunay/Voronoi with a *New Points* button and a point-count slider.
- **Feature Matching** — KAZE/SIFT toggle, a **Matches Found / Object Located** stat row, and a *Change Images* picker (built-in Emgu samples or a photo from the library).
- **Unicode Rendering** — type any text and render it with FontFace/FreeType.

## Scope
Demo app only (7 files under `Emgu.CV.Example/MAUI/MauiDemoApp/`); **no library or native code changed**. Built and run on a physical iPhone (iOS 26.5).