### PR TITLE
MAUI demo: lock the app to portrait on phones

### DIFF
--- a/Emgu.CV.Example/MAUI/MauiDemoApp/Platforms/Android/MainActivity.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace MauiDemoApp
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ScreenOrientation = ScreenOrientation.Portrait, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
         protected override void OnCreate(Bundle savedInstanceState)

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/Platforms/iOS/Info.plist
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/Platforms/iOS/Info.plist
@@ -16,8 +16,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
## What

Locks the MAUI demo to **portrait** on phones. Several pages are laid out for a vertical screen and either break or look wrong when rotated to landscape.

- **iPhone**: `Info.plist` `UISupportedInterfaceOrientations` → Portrait only.
- **Android**: `MainActivity` → `ScreenOrientation = ScreenOrientation.Portrait`.

iPad orientations are left unchanged.

## Scope
Demo app only (2 platform-config files); no library or native code. Verified on a physical iPhone — the app now stays vertical.