### PR TITLE
FileDownloadManager: optional confirm-before-download hook (+ demo size prompt)

### DIFF
--- a/Emgu.CV.Example/MAUI/MauiDemoApp/App.xaml.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/App.xaml.cs
@@ -12,6 +12,25 @@
             UserAppTheme = AppTheme.Light;
 
             Emgu.CV.Platform.Maui.MauiInvoke.Init();
+
+            // Ask before any model download, showing the total size. Runs on the
+            // main thread (the download happens on a background thread).
+            Emgu.Util.FileDownloadManager.DownloadConfirmation = (long bytes) =>
+                Microsoft.Maui.ApplicationModel.MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    double mb = bytes / (1024.0 * 1024.0);
+                    string size = bytes <= 0 ? "some"
+                        : mb >= 1024 ? $"{mb / 1024.0:0.0} GB"
+                        : mb >= 1 ? $"{mb:0} MB"
+                        : $"{bytes / 1024.0:0} KB";
+                    Page? page = Shell.Current;
+                    if (page == null)
+                        return System.Threading.Tasks.Task.FromResult(true);
+                    return page.DisplayAlert(
+                        "Download model?",
+                        $"This feature needs to download about {size} of model files (uses internet data). Download now?",
+                        "Download", "Cancel");
+                });
         }
 
         protected override Window CreateWindow(IActivationState? activationState)

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/App.xaml.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/App.xaml.cs
@@ -26,7 +26,7 @@
                     Page? page = Shell.Current;
                     if (page == null)
                         return System.Threading.Tasks.Task.FromResult(true);
-                    return page.DisplayAlert(
+                    return page.DisplayAlertAsync(
                         "Download model?",
                         $"This feature needs to download about {size} of model files (uses internet data). Download now?",
                         "Download", "Cancel");

--- a/Emgu.Util/FileDownloadManager.cs
+++ b/Emgu.Util/FileDownloadManager.cs
@@ -144,13 +144,57 @@ namespace Emgu.Util
         }
 #else
         /// <summary>
-        /// Download the files. 
+        /// Optional confirmation invoked before any file is downloaded. It receives the
+        /// estimated total number of bytes still to download (files not already present);
+        /// return false to abort the download. When null (the default) downloads proceed
+        /// without asking, so existing behaviour is unchanged. Lets a UI prompt the user
+        /// before large model downloads.
+        /// </summary>
+        public static Func<long, Task<bool>> DownloadConfirmation = null;
+
+        /// <summary>
+        /// Download the files.
         /// </summary>
         /// <param name="retry">The number of retries.</param>
         /// <returns>The async Task</returns>
         public async Task Download(int retry = 1)
         {
-            await Download( _files.ToArray(), retry, this.OnDownloadProgressChanged);
+            DownloadableFile[] files = _files.ToArray();
+
+            var confirm = DownloadConfirmation;
+            if (confirm != null)
+            {
+                long total = 0;
+                bool anyPending = false;
+                foreach (DownloadableFile f in files)
+                {
+                    if (f.Url != null && !f.IsLocalFileValid)
+                    {
+                        anyPending = true;
+                        total += await GetRemoteSizeAsync(f.Url);
+                    }
+                }
+                if (anyPending && !await confirm(total))
+                    throw new OperationCanceledException("Download cancelled by the user.");
+            }
+
+            await Download(files, retry, this.OnDownloadProgressChanged);
+        }
+
+        // HEAD the url to read its Content-Length (0 if unavailable). Follows redirects.
+        private static async Task<long> GetRemoteSizeAsync(String url)
+        {
+            try
+            {
+                using (var http = new System.Net.Http.HttpClient())
+                using (var req = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Head, url))
+                using (var resp = await http.SendAsync(req, System.Net.Http.HttpCompletionOption.ResponseHeadersRead))
+                    return resp.Content.Headers.ContentLength ?? 0;
+            }
+            catch
+            {
+                return 0;
+            }
         }
 
         private static async Task Download(


### PR DESCRIPTION
## What

Adds an optional **`FileDownloadManager.DownloadConfirmation`** callback that runs **before** any file is downloaded. It receives the estimated total bytes still to download (measured via HTTP HEAD of the pending files) and returns whether to proceed; returning false aborts.

When unset (the default), downloads proceed exactly as before — **no behaviour change** for existing callers.

## Why

Some demo models are large (LLMs, super-res, Mask R-CNN). On metered/cellular connections it's easy to kick off a big download by accident. This lets a UI **ask first and show the size**.

## Demo

`App.xaml.cs` sets the callback to a popup: *"This feature needs to download about NNN MB of model files — Download / Cancel."* Works for every module automatically (no per-model changes).

## Scope
One small library method in `Emgu.Util/FileDownloadManager.cs` + the demo hookup in `App.xaml.cs` (2 files). Backward-compatible. Built + deployed to a physical iPhone.