### PR TITLE
MAUI demo: add LLM tab + fix obsolete APIs (+ Feature Matching crash fix)

### DIFF
--- a/Emgu.CV.Example/MAUI/MauiDemoApp/FeatureMatchingPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/FeatureMatchingPage.cs
@@ -3,6 +3,7 @@
 //----------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -177,7 +178,7 @@ namespace MauiDemoApp
             string name;
             if (choice == "library")
             {
-                FileResult file = await MediaPicker.Default.PickPhotoAsync();
+                FileResult file = (await MediaPicker.Default.PickPhotosAsync())?.FirstOrDefault();
                 if (file == null)
                     return;
                 SetBusy(true, "Loading photo…");
@@ -195,7 +196,7 @@ namespace MauiDemoApp
             }
             if (m == null)
             {
-                await DisplayAlert("Feature Matching", "That image could not be loaded.", "OK");
+                await DisplayAlertAsync("Feature Matching", "That image could not be loaded.", "OK");
                 return;
             }
 
@@ -238,7 +239,7 @@ namespace MauiDemoApp
             }
             catch (Exception ex)
             {
-                await DisplayAlert("Feature Matching", ex.Message, "OK");
+                await DisplayAlertAsync("Feature Matching", ex.Message, "OK");
             }
             finally
             {
@@ -276,6 +277,18 @@ namespace MauiDemoApp
             Mat m = new Mat();
             CvInvoke.Imdecode(bytes, ImreadModes.ColorBgr, m);
             if (m.IsEmpty) { m.Dispose(); return null; }
+            // Full-resolution phone photos (12MP+) can exhaust memory when run
+            // through SIFT/KAZE and crash the native side. Cap the longest side.
+            const int maxSide = 1600;
+            int longest = Math.Max(m.Width, m.Height);
+            if (longest > maxSide)
+            {
+                double scale = (double)maxSide / longest;
+                Mat resized = new Mat();
+                CvInvoke.Resize(m, resized, System.Drawing.Size.Empty, scale, scale, Inter.Area);
+                m.Dispose();
+                return resized;
+            }
             return m;
         }
     }

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/MainPage.xaml.cs
@@ -548,17 +548,21 @@ namespace MauiDemoApp
             };
 
             // ---------- Sort the demo buttons into broad groups ----------
-            string[] categoryNames = { "Detection", "Image & 3D", "Video" };
+            string[] categoryNames = { "Detection", "Image & 3D", "Video", "LLM" };
             string[] pillGlyphs = { "", "", "" }; // crop_free, view_in_ar, smart_display // crop_free, view_in_ar, smart_display
-            var categoryDemos = new List<Button>[] { new List<Button>(), new List<Button>(), new List<Button>() };
+            // Extend the pill glyphs for the new LLM tab. Reuse the existing three by
+            // index (so the glyph characters don't have to be retyped) and give LLM the
+            // qwen glyph.
+            pillGlyphs = new string[] { pillGlyphs[0], pillGlyphs[1], pillGlyphs[2], demoGlyph("qwen") };
+            var categoryDemos = new List<Button>[] { new List<Button>(), new List<Button>(), new List<Button>(), new List<Button>() };
 
             Func<string, int> categorize = (text) =>
             {
                 string t = (text ?? "").ToLowerInvariant();
+                if (t.Contains("qwen") || t.Contains("smolvlm")) return 3;   // LLM
                 if (t.Contains("video")) return 2;
                 if (t.Contains("hello") || t.Contains("planar") || t.Contains("feature matching")
-                    || t.Contains("super resolution") || t.Contains("3d") || t.Contains("unicode")
-                    || t.Contains("qwen") || t.Contains("smolvlm"))
+                    || t.Contains("super resolution") || t.Contains("3d") || t.Contains("unicode"))
                     return 1;
                 return 0;
             };

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/MaskRcnnPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/MaskRcnnPage.cs
@@ -353,7 +353,7 @@ namespace MauiDemoApp
             {
                 FileResult file = action == "camera"
                     ? await MediaPicker.Default.CapturePhotoAsync()
-                    : await MediaPicker.Default.PickPhotoAsync();
+                    : (await MediaPicker.Default.PickPhotosAsync())?.FirstOrDefault();
                 if (file == null)
                     return;
 
@@ -367,7 +367,7 @@ namespace MauiDemoApp
                 if (m.IsEmpty)
                 {
                     m.Dispose();
-                    await DisplayAlert("Photo", "That file could not be read as an image.", "OK");
+                    await DisplayAlertAsync("Photo", "That file could not be read as an image.", "OK");
                     return;
                 }
                 SetCurrentImage(Downscale(m, 1024));
@@ -375,7 +375,7 @@ namespace MauiDemoApp
             catch (Exception ex)
             {
                 SetBusy(false);
-                await DisplayAlert("Could not load photo", ex.Message, "OK");
+                await DisplayAlertAsync("Could not load photo", ex.Message, "OK");
             }
         }
 
@@ -443,8 +443,8 @@ namespace MauiDemoApp
             _sheetScrim.Opacity = 0;
             _sheetCard.TranslationY = 700;
             _ = Task.WhenAll(
-                _sheetScrim.FadeTo(1, 220, Easing.CubicOut),
-                _sheetCard.TranslateTo(0, 0, 260, Easing.CubicOut));
+                _sheetScrim.FadeToAsync(1, 220, Easing.CubicOut),
+                _sheetCard.TranslateToAsync(0, 0, 260, Easing.CubicOut));
             return _sheetTcs.Task;
         }
 
@@ -454,8 +454,8 @@ namespace MauiDemoApp
                 return;
             _sheetAnimating = true;
             await Task.WhenAll(
-                _sheetScrim.FadeTo(0, 180, Easing.CubicIn),
-                _sheetCard.TranslateTo(0, 700, 220, Easing.CubicIn));
+                _sheetScrim.FadeToAsync(0, 180, Easing.CubicIn),
+                _sheetCard.TranslateToAsync(0, 700, 220, Easing.CubicIn));
             _sheetOverlay.IsVisible = false;
             _sheetAnimating = false;
             _sheetTcs?.TrySetResult(value);
@@ -773,7 +773,7 @@ namespace MauiDemoApp
         public MaskRcnnLivePage()
         {
             BackgroundColor = MaskRcnnPage.PageBackground;
-            On<Microsoft.Maui.Controls.PlatformConfiguration.iOS>().SetUseSafeArea(true);
+            this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.All;
             AllowAvCaptureSession = true;
             outputRecorder.BufferReceived += OnCameraFrame;
 
@@ -814,7 +814,7 @@ namespace MauiDemoApp
                 Content = MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphInfo, MaskRcnnPage.PrimaryText, 20)
             };
             var infoTap = new TapGestureRecognizer();
-            infoTap.Tapped += async (s, e) => await DisplayAlert("Live Detection", "Point your camera at objects. Each detected object is boxed and labeled in real time.", "OK");
+            infoTap.Tapped += async (s, e) => await DisplayAlertAsync("Live Detection", "Point your camera at objects. Each detected object is boxed and labeled in real time.", "OK");
             infoBtn.GestureRecognizers.Add(infoTap);
 
             var topBar = new Grid

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
@@ -3,6 +3,7 @@
 //----------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -440,7 +441,7 @@ namespace MauiDemoApp
             {
                 FileResult file = action == "camera"
                     ? await MediaPicker.Default.CapturePhotoAsync()
-                    : await MediaPicker.Default.PickPhotoAsync();
+                    : (await MediaPicker.Default.PickPhotosAsync())?.FirstOrDefault();
                 if (file == null)
                     return;
 
@@ -454,7 +455,7 @@ namespace MauiDemoApp
                 if (m.IsEmpty)
                 {
                     m.Dispose();
-                    await DisplayAlert("Photo", "That file could not be read as an image.", "OK");
+                    await DisplayAlertAsync("Photo", "That file could not be read as an image.", "OK");
                     return;
                 }
                 SetCurrentImage(MaskRcnnPage.Downscale(m, 1024));
@@ -462,7 +463,7 @@ namespace MauiDemoApp
             catch (Exception ex)
             {
                 SetBusy(false);
-                await DisplayAlert("Could not load photo", ex.Message, "OK");
+                await DisplayAlertAsync("Could not load photo", ex.Message, "OK");
             }
         }
 
@@ -530,8 +531,8 @@ namespace MauiDemoApp
             _sheetScrim.Opacity = 0;
             _sheetCard.TranslationY = 700;
             _ = Task.WhenAll(
-                _sheetScrim.FadeTo(1, 220, Easing.CubicOut),
-                _sheetCard.TranslateTo(0, 0, 260, Easing.CubicOut));
+                _sheetScrim.FadeToAsync(1, 220, Easing.CubicOut),
+                _sheetCard.TranslateToAsync(0, 0, 260, Easing.CubicOut));
             return _sheetTcs.Task;
         }
 
@@ -541,8 +542,8 @@ namespace MauiDemoApp
                 return;
             _sheetAnimating = true;
             await Task.WhenAll(
-                _sheetScrim.FadeTo(0, 180, Easing.CubicIn),
-                _sheetCard.TranslateTo(0, 700, 220, Easing.CubicIn));
+                _sheetScrim.FadeToAsync(0, 180, Easing.CubicIn),
+                _sheetCard.TranslateToAsync(0, 700, 220, Easing.CubicIn));
             _sheetOverlay.IsVisible = false;
             _sheetAnimating = false;
             _sheetTcs?.TrySetResult(value);
@@ -811,7 +812,7 @@ namespace MauiDemoApp
             {
                 expanded = !expanded;
                 details.IsVisible = expanded;
-                await chevron.RotateTo(expanded ? 90 : 0, 180, Easing.CubicOut);
+                await chevron.RotateToAsync(expanded ? 90 : 0, 180, Easing.CubicOut);
             };
             headerRow.GestureRecognizers.Add(tap);
 
@@ -878,7 +879,7 @@ namespace MauiDemoApp
             _pickerSelection = pickerSelection;
 
             BackgroundColor = MaskRcnnPage.PageBackground;
-            On<Microsoft.Maui.Controls.PlatformConfiguration.iOS>().SetUseSafeArea(true);
+            this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.All;
             AllowAvCaptureSession = true;
             outputRecorder.BufferReceived += OnCameraFrame;
 

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/SimpleDemoPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/SimpleDemoPage.cs
@@ -145,8 +145,8 @@ namespace MauiDemoApp
             _sheetScrim.Opacity = 0;
             _sheetCard.TranslationY = 700;
             _ = System.Threading.Tasks.Task.WhenAll(
-                _sheetScrim.FadeTo(1, 220, Easing.CubicOut),
-                _sheetCard.TranslateTo(0, 0, 260, Easing.CubicOut));
+                _sheetScrim.FadeToAsync(1, 220, Easing.CubicOut),
+                _sheetCard.TranslateToAsync(0, 0, 260, Easing.CubicOut));
             return _sheetTcs.Task;
         }
 
@@ -208,8 +208,8 @@ namespace MauiDemoApp
                 return;
             _sheetAnimating = true;
             await System.Threading.Tasks.Task.WhenAll(
-                _sheetScrim.FadeTo(0, 180, Easing.CubicIn),
-                _sheetCard.TranslateTo(0, 700, 220, Easing.CubicIn));
+                _sheetScrim.FadeToAsync(0, 180, Easing.CubicIn),
+                _sheetCard.TranslateToAsync(0, 700, 220, Easing.CubicIn));
             _sheetOverlay.IsVisible = false;
             _sheetAnimating = false;
             _sheetTcs?.TrySetResult(value);

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/UnicodeRenderingPage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/UnicodeRenderingPage.cs
@@ -143,7 +143,7 @@ namespace MauiDemoApp
             catch (Exception ex)
             {
                 _status.Text = "Error";
-                await DisplayAlert("Unicode Rendering", ex.Message, "OK");
+                await DisplayAlertAsync("Unicode Rendering", ex.Message, "OK");
             }
             finally
             {


### PR DESCRIPTION
Demo-app only — no library or native changes.

### 1. Add an LLM tab
Adds a fourth home category **LLM** and moves the two conversational models — **Qwen Chat** and **Chat with Image (SmolVLM2)** — into it, out of *Image & 3D* (which otherwise holds detection/geometry demos).

### 2. Fix obsolete MAUI APIs
Clears all obsolete (CS0618) build warnings in the demo pages by swapping deprecated MAUI calls for their current equivalents — no behaviour change:
- `DisplayAlert` → `DisplayAlertAsync`
- `FadeTo` / `TranslateTo` / `RotateTo` → `*Async`
- `MediaPicker.PickPhotoAsync` → `PickPhotosAsync().FirstOrDefault()`
- `On<iOS>().SetUseSafeArea(true)` → `SafeAreaEdges = SafeAreaEdges.All`

### 3. Fix a Feature Matching crash on large photos
Selecting a full-resolution library photo (12MP+) and running SIFT/KAZE on it could exhaust memory and crash natively. `Decode()` now caps the longest side to 1600px.

Verified on device (iPhone): LLM tab, all pages, and Feature Matching with a large library photo all work; 0 obsolete warnings.