### PR TITLE
Fix link: FastFeatureDetector & ORB property guards use #if on a valueless HAVE_OPENCV_FEATURES

### DIFF
--- a/Emgu.CV.Extern/CMakeLists.txt
+++ b/Emgu.CV.Extern/CMakeLists.txt
@@ -1603,7 +1603,7 @@ ENDIF()
 	""
     "#include \"features_c.h\""
 	""
-	"HAVE_OPENCV_FEATURES"
+	""
 	${HAVE_opencv_features})
   CREATE_OCV_CLASS_PROPERTY(
     "features/ORB_property"
@@ -1630,7 +1630,7 @@ ENDIF()
 	""
     "#include \"features_c.h\""
 	""
-	"HAVE_OPENCV_FEATURES"
+	""
 	${HAVE_opencv_features})
 
 ############################### features code gen END ################################


### PR DESCRIPTION
### Problem
The `CREATE_OCV_CLASS_PROPERTY` calls for `FastFeatureDetector` and `ORB` pass `"HAVE_OPENCV_FEATURES"` as the C compilation condition. The macro emits that as `#if HAVE_OPENCV_FEATURES`. Since OpenCV defines `HAVE_OPENCV_*` **without a value**, `#if HAVE_OPENCV_FEATURES` evaluates false and the generated `FastFeatureDetector_property.cpp` / `ORB_property.cpp` compile to **no symbols**.

Result: link failure with undefined `cveFastFeatureDetector*` and `cveORB*` symbols (hit on an iOS device build; `libtool` also warns `FastFeatureDetector_property.o has no symbols`).

### Fix
These are the only two `CREATE_OCV_CLASS_PROPERTY` calls (of ~79) that pass a C compilation condition. Every other call passes an empty condition and relies on the `ocv_module_enabled` argument (`${HAVE_opencv_features}`) for the dummy-stub mechanism. This change does the same for these two, so real implementations are generated when the features module is enabled.

2 lines changed.