### PR TITLE
MAUI demo: redesign the Video Surveillance live view

### DIFF
--- a/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
@@ -333,7 +333,12 @@ namespace MauiDemoApp
                 Padding = new Thickness(16),
                 Content = new VerticalStackLayout { Spacing = 12, Children = { resultsHeader, _emptyState, _resultsBody } }
             };
-            pageChildren.Children.Add(resultsCard);
+            // The Results card only ever populates on the still-image path; for
+            // camera-only modules the live feed opens on its own full-screen page,
+            // so this card would sit permanently on "No results yet". Only show it
+            // when there's a still-image flow to report into.
+            if (_hasStillImage)
+                pageChildren.Children.Add(resultsCard);
 
             // ---------- About this module (collapsible) ----------
             if (!string.IsNullOrWhiteSpace(_about))

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
@@ -890,6 +890,8 @@ namespace MauiDemoApp
 
             _feed = new Image { Aspect = Aspect.AspectFill, HorizontalOptions = LayoutOptions.Fill, VerticalOptions = LayoutOptions.Fill };
 
+            // Floating exit control (white on a translucent pill) so the video
+            // can run edge-to-edge with no chrome bar stealing vertical space.
             var exitRow = new HorizontalStackLayout
             {
                 Spacing = 2,
@@ -897,9 +899,20 @@ namespace MauiDemoApp
                 HorizontalOptions = LayoutOptions.Start,
                 Children =
                 {
-                    MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphChevronLeft, MaskRcnnPage.Accent, 24),
-                    new Label { Text = "Exit", FontFamily = MaskRcnnPage.TitleFont, FontSize = 17, TextColor = MaskRcnnPage.Accent, VerticalOptions = LayoutOptions.Center }
+                    MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphChevronLeft, Colors.White, 24),
+                    new Label { Text = "Exit", FontFamily = MaskRcnnPage.TitleFont, FontSize = 17, TextColor = Colors.White, VerticalOptions = LayoutOptions.Center }
                 }
+            };
+            var exitPill = new Border
+            {
+                BackgroundColor = Color.FromArgb("#E01A1C2E"),
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(18) },
+                Padding = new Thickness(14, 8, 18, 8),
+                Margin = new Thickness(12, 12, 0, 0),
+                HorizontalOptions = LayoutOptions.Start,
+                VerticalOptions = LayoutOptions.Start,
+                Content = exitRow
             };
             var exitTap = new TapGestureRecognizer();
             exitTap.Tapped += async (s, e) =>
@@ -907,18 +920,7 @@ namespace MauiDemoApp
                 _running = false;
                 await Navigation.PopModalAsync();
             };
-            exitRow.GestureRecognizers.Add(exitTap);
-
-            var titleLabel = new Label { Text = title, FontFamily = MaskRcnnPage.TitleFont, FontSize = 18, TextColor = MaskRcnnPage.PrimaryText, HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
-
-            var topBar = new Grid
-            {
-                Padding = new Thickness(16, 8, 16, 10),
-                ColumnDefinitions = { new ColumnDefinition(GridLength.Auto), new ColumnDefinition(GridLength.Star), new ColumnDefinition(GridLength.Auto) }
-            };
-            topBar.Add(titleLabel, 0, 0);
-            Grid.SetColumnSpan(titleLabel, 3);
-            topBar.Add(exitRow, 0, 0);
+            exitPill.GestureRecognizers.Add(exitTap);
 
             var dot = new Border { WidthRequest = 10, HeightRequest = 10, BackgroundColor = Color.FromArgb("#2BE07A"), Stroke = Colors.Transparent, StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(5) }, VerticalOptions = LayoutOptions.Center };
             var scanningTitle = new Label { Text = "Scanning…", FontFamily = MaskRcnnPage.TitleFont, FontSize = 15, TextColor = Colors.White };
@@ -943,26 +945,15 @@ namespace MauiDemoApp
                 }
             };
 
-            var feedCard = new Border
-            {
-                BackgroundColor = Colors.Black,
-                Stroke = MaskRcnnPage.RowBorder,
-                StrokeThickness = 1,
-                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(24) },
-                Margin = new Thickness(16, 4, 16, 20),
-                Content = new Grid { Children = { _feed, pill } }
-            };
-
             _spinner = new ActivityIndicator { IsRunning = false, Color = MaskRcnnPage.Accent, WidthRequest = 44, HeightRequest = 44, HorizontalOptions = LayoutOptions.Center };
             _loadingLabel = new Label { Text = "Starting camera…", FontFamily = MaskRcnnPage.BodyFont, FontSize = 15, TextColor = MaskRcnnPage.PrimaryText, HorizontalOptions = LayoutOptions.Center, HorizontalTextAlignment = TextAlignment.Center };
             var loadingBox = new VerticalStackLayout { Spacing = 14, VerticalOptions = LayoutOptions.Center, HorizontalOptions = LayoutOptions.Center, Children = { _spinner, _loadingLabel } };
             _overlay = new Grid { BackgroundColor = Color.FromArgb("#F5EEF1F8"), Children = { loadingBox } };
 
-            var root = new Grid { RowDefinitions = { new RowDefinition(GridLength.Auto), new RowDefinition(GridLength.Star) } };
-            root.Add(topBar, 0, 0);
-            root.Add(feedCard, 0, 1);
-
-            Content = new Grid { Children = { root, _overlay } };
+            // Edge-to-edge: the feed fills the whole page (theme background behind
+            // it), with the exit control and scanning pill floating on top — no
+            // chrome bar or card margin stealing space from the video.
+            Content = new Grid { BackgroundColor = MaskRcnnPage.PageBackground, Children = { _feed, exitPill, pill, _overlay } };
         }
 
         protected override async void OnAppearing()

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/ModelShowcasePage.cs
@@ -877,11 +877,15 @@ namespace MauiDemoApp
         private bool _started;
         private Mat _frame;
         private Mat _renderMat;
+        private readonly IMultiPaneModel _paneModel;
+        private View _splitControls;
+        private View _collapseControl;
 
         public ModelShowcaseLivePage(string title, Func<IProcessAndRenderModel> modelFactory, string pickerSelection)
         {
             _model = modelFactory();
             _pickerSelection = pickerSelection;
+            _paneModel = _model as IMultiPaneModel;
 
             BackgroundColor = MaskRcnnPage.PageBackground;
             this.SafeAreaEdges = Microsoft.Maui.SafeAreaEdges.All;
@@ -951,9 +955,111 @@ namespace MauiDemoApp
             _overlay = new Grid { BackgroundColor = Color.FromArgb("#F5EEF1F8"), Children = { loadingBox } };
 
             // Edge-to-edge: the feed fills the whole page (theme background behind
-            // it), with the exit control and scanning pill floating on top — no
-            // chrome bar or card margin stealing space from the video.
-            Content = new Grid { BackgroundColor = MaskRcnnPage.PageBackground, Children = { _feed, exitPill, pill, _overlay } };
+            // it), with the exit control and floating pills on top — no chrome bar
+            // or card margin stealing space from the video.
+            var layers = new Grid { BackgroundColor = MaskRcnnPage.PageBackground };
+            layers.Children.Add(_feed);
+            layers.Children.Add(exitPill);
+            layers.Children.Add(pill);
+            // When the model exposes stacked panes (e.g. Video Surveillance),
+            // overlay a per-pane expand control so either pane can go full-screen.
+            if (_paneModel != null)
+            {
+                BuildPaneControls();
+                layers.Children.Add(_splitControls);
+                layers.Children.Add(_collapseControl);
+            }
+            layers.Children.Add(_overlay);
+            Content = layers;
+        }
+
+        private void BuildPaneControls()
+        {
+            var names = _paneModel.PaneNames;
+
+            // A translucent pill that pops a pane full-screen when tapped, laid
+            // into row `index` of a 2-row grid so it sits over that pane.
+            Func<int, string, View> expandPill = (index, name) =>
+            {
+                var row = new HorizontalStackLayout
+                {
+                    Spacing = 4,
+                    Children =
+                    {
+                        new Label { Text = name, FontFamily = MaskRcnnPage.TitleFont, FontSize = 14, TextColor = Colors.White, VerticalOptions = LayoutOptions.Center },
+                        MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphChevronRight, Colors.White, 18)
+                    }
+                };
+                var border = new Border
+                {
+                    BackgroundColor = Color.FromArgb("#E01A1C2E"),
+                    Stroke = Colors.Transparent,
+                    StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(16) },
+                    Padding = new Thickness(12, 6, 10, 6),
+                    HorizontalOptions = LayoutOptions.End,
+                    VerticalOptions = LayoutOptions.Start,
+                    Margin = new Thickness(0, 12, 12, 0),
+                    Content = row
+                };
+                var tap = new TapGestureRecognizer();
+                tap.Tapped += (s, e) => SetFocusedPane(index);
+                border.GestureRecognizers.Add(tap);
+                return border;
+            };
+
+            // The grid spans the whole screen to align a pill over each pane, but
+            // must not swallow taps meant for the controls beneath it (e.g. Exit);
+            // pass empty-area touches through while keeping the pills tappable.
+            var splitGrid = new Grid
+            {
+                RowDefinitions = { new RowDefinition(GridLength.Star), new RowDefinition(GridLength.Star) },
+                InputTransparent = true,
+                CascadeInputTransparent = false
+            };
+            for (int i = 0; i < names.Length && i < 2; i++)
+            {
+                var p = expandPill(i, names[i]);
+                Grid.SetRow(p, i);
+                splitGrid.Children.Add(p);
+            }
+            _splitControls = splitGrid;
+
+            var collapseRow = new HorizontalStackLayout
+            {
+                Spacing = 2,
+                Children =
+                {
+                    MaskRcnnPage.MakeIcon(MaskRcnnPage.GlyphChevronLeft, Colors.White, 20),
+                    new Label { Text = "Split", FontFamily = MaskRcnnPage.TitleFont, FontSize = 15, TextColor = Colors.White, VerticalOptions = LayoutOptions.Center }
+                }
+            };
+            var collapseBorder = new Border
+            {
+                BackgroundColor = Color.FromArgb("#E01A1C2E"),
+                Stroke = Colors.Transparent,
+                StrokeShape = new RoundRectangle { CornerRadius = new CornerRadius(16) },
+                Padding = new Thickness(10, 6, 14, 6),
+                HorizontalOptions = LayoutOptions.End,
+                VerticalOptions = LayoutOptions.Start,
+                Margin = new Thickness(0, 12, 12, 0),
+                IsVisible = false,
+                Content = collapseRow
+            };
+            var ctap = new TapGestureRecognizer();
+            ctap.Tapped += (s, e) => SetFocusedPane(-1);
+            collapseBorder.GestureRecognizers.Add(ctap);
+            _collapseControl = collapseBorder;
+        }
+
+        private void SetFocusedPane(int index)
+        {
+            if (_paneModel == null)
+                return;
+            _paneModel.FocusedPane = index;
+            // Split preview crops to fill; a focused single pane shows uncropped.
+            _feed.Aspect = index < 0 ? Aspect.AspectFill : Aspect.AspectFit;
+            _splitControls.IsVisible = index < 0;
+            _collapseControl.IsVisible = index >= 0;
         }
 
         protected override async void OnAppearing()

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/VideoSurveillanceModel.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/VideoSurveillanceModel.cs
@@ -18,9 +18,35 @@ using System.Diagnostics;
 
 namespace Emgu.CV.Models
 {
-
-    public class VideoSurveillanceModel : DisposableObject, IProcessAndRenderModel
+    /// <summary>
+    /// Optional capability for a model that renders several stacked panes and can
+    /// focus a single pane full-screen. A hosting page can offer per-pane expand
+    /// controls when the model implements this.
+    /// </summary>
+    public interface IMultiPaneModel
     {
+        /// <summary>Pane labels, top to bottom.</summary>
+        string[] PaneNames { get; }
+
+        /// <summary>-1 shows all panes stacked; otherwise the pane index shown full-screen.</summary>
+        int FocusedPane { get; set; }
+    }
+
+    public class VideoSurveillanceModel : DisposableObject, IProcessAndRenderModel, IMultiPaneModel
+    {
+        // -1 shows both panes stacked; 0 = camera only, 1 = motion mask only.
+        private int _focusedPane = -1;
+
+        /// <summary>Pane labels, top to bottom, for the multi-pane host UI.</summary>
+        public string[] PaneNames => new[] { "Camera", "Motion" };
+
+        /// <summary>Which pane to show full-screen (-1 = both stacked).</summary>
+        public int FocusedPane
+        {
+            get => _focusedPane;
+            set => _focusedPane = value;
+        }
+
         /// <summary>
         /// The rendering method
         /// </summary>
@@ -255,16 +281,29 @@ namespace Emgu.CV.Models
                 }
 
                 //foregroundMaskBgr.CopyTo(imageOut);
-                // Stack the tracked frame above the foreground mask, separated by
-                // a thin white divider so the two panes read as distinct. Vertical
-                // (not horizontal) concat keeps each pane usefully sized on a
-                // portrait phone, where a double-wide image would shrink to a thin
-                // strip.
-                int dividerHeight = Math.Max(2, _frameCopy.Height / 120);
-                using (Mat divider = new Mat(dividerHeight, _frameCopy.Width, _frameCopy.Depth, _frameCopy.NumberOfChannels))
+                if (_focusedPane == 0)
                 {
-                    divider.SetTo(new MCvScalar(255.0, 255.0, 255.0));
-                    CvInvoke.VConcat(new Mat[] { _frameCopy, divider, _foregroundMaskBgr }, imageOut);
+                    // Camera pane only, full-screen.
+                    _frameCopy.CopyTo(imageOut);
+                }
+                else if (_focusedPane == 1)
+                {
+                    // Motion (foreground mask) pane only, full-screen.
+                    _foregroundMaskBgr.CopyTo(imageOut);
+                }
+                else
+                {
+                    // Stack the tracked frame above the foreground mask, separated
+                    // by a thin white divider so the two panes read as distinct.
+                    // Vertical (not horizontal) concat keeps each pane usefully
+                    // sized on a portrait phone, where a double-wide image would
+                    // shrink to a thin strip.
+                    int dividerHeight = Math.Max(2, _frameCopy.Height / 120);
+                    using (Mat divider = new Mat(dividerHeight, _frameCopy.Width, _frameCopy.Depth, _frameCopy.NumberOfChannels))
+                    {
+                        divider.SetTo(new MCvScalar(255.0, 255.0, 255.0));
+                        CvInvoke.VConcat(new Mat[] { _frameCopy, divider, _foregroundMaskBgr }, imageOut);
+                    }
                 }
 
             }

--- a/Emgu.CV.Example/MAUI/MauiDemoApp/VideoSurveillanceModel.cs
+++ b/Emgu.CV.Example/MAUI/MauiDemoApp/VideoSurveillanceModel.cs
@@ -255,7 +255,17 @@ namespace Emgu.CV.Models
                 }
 
                 //foregroundMaskBgr.CopyTo(imageOut);
-                CvInvoke.HConcat(_frameCopy, _foregroundMaskBgr, imageOut);
+                // Stack the tracked frame above the foreground mask, separated by
+                // a thin white divider so the two panes read as distinct. Vertical
+                // (not horizontal) concat keeps each pane usefully sized on a
+                // portrait phone, where a double-wide image would shrink to a thin
+                // strip.
+                int dividerHeight = Math.Max(2, _frameCopy.Height / 120);
+                using (Mat divider = new Mat(dividerHeight, _frameCopy.Width, _frameCopy.Depth, _frameCopy.NumberOfChannels))
+                {
+                    divider.SetTo(new MCvScalar(255.0, 255.0, 255.0));
+                    CvInvoke.VConcat(new Mat[] { _frameCopy, divider, _foregroundMaskBgr }, imageOut);
+                }
 
             }
             watch.Stop();


### PR DESCRIPTION
### Problem
On a portrait phone the Video Surveillance demo `HConcat`'d the tracked frame and foreground mask **side-by-side**, so the double-wide image shrank to unusable thin strips.

### Changes (4 commits)
1. **Hide the empty Results card on camera-only modules** — it only ever populated from the still-image path, so for camera-only modules (which open the live feed on a separate full-screen page) it sat permanently on "No results yet".
2. **Stack the panes vertically** — `HConcat`→`VConcat` so the camera view sits above the foreground mask (50/50), with a thin white divider between them.
3. **Edge-to-edge live camera** — drop the bordered feed card + top chrome bar; the feed fills the screen with a floating translucent "‹ Exit" pill (shared `ModelShowcaseLivePage`, so all camera modules get the full-screen look).
4. **Per-pane expand/collapse** — a new optional `IMultiPaneModel` capability (implemented only by `VideoSurveillanceModel`) lets the live page overlay a pill on each pane ("Camera ›" / "Motion ›"); tapping one pops that pane full-screen and uncropped, with "‹ Split" to return. Other modules are unaffected.

### Notes
- Built and run on an iOS device.
- The per-pane overlay grid is `InputTransparent` (no cascade) so it aligns a pill over each pane without swallowing taps meant for Exit.